### PR TITLE
Update uuid to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.4"
 log = "0.3"
 num = "0.1"
 quick-error = "1.2"
-uuid = "0.4"
+uuid = "0.6"
 
 [badges]
 travis-ci = { repository = "gadomski/las-rs" }


### PR DESCRIPTION
Hey

Updating this crate to 0.6 since the new release is out. There are no further changes required.