### PR TITLE
Fix clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["science", "data-structures"]
 [dependencies]
 byteorder = "1.1"
 chrono = "0.4"
-log = "0.3"
+log = "0.4"
 num = "0.1"
 quick-error = "1.2"
 uuid = "0.6"

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -5,9 +5,9 @@ extern crate las;
 use las::Reader;
 
 fn main() {
-    let path = std::env::args().skip(1).next().expect(
-        "Must provide a path to a las file",
-    );
+    let path = std::env::args()
+        .nth(1)
+        .expect("Must provide a path to a las file");
     let mut reader = Reader::from_path(path).expect("Unable to open reader");
     let npoints = reader
         .points()

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,5 +1,5 @@
-use {Point, Vector};
 use std::f64;
+use {Point, Vector};
 
 /// Minimum and maximum bounds in three dimensions.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -68,8 +68,11 @@ mod tests {
     use Point;
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn grow() {
-        let mut bounds = Bounds { ..Default::default() };
+        let mut bounds = Bounds {
+            ..Default::default()
+        };
         bounds.grow(&Point {
             x: 1.,
             y: 2.,

--- a/src/gps_time_type.rs
+++ b/src/gps_time_type.rs
@@ -17,8 +17,8 @@ impl GpsTimeType {
     /// assert!(!GpsTimeType::Week.is_standard());
     /// assert!(GpsTimeType::Standard.is_standard());
     /// ```
-    pub fn is_standard(&self) -> bool {
-        match *self {
+    pub fn is_standard(self) -> bool {
+        match self {
             GpsTimeType::Week => false,
             GpsTimeType::Standard => true,
         }

--- a/src/header/builder.rs
+++ b/src/header/builder.rs
@@ -70,6 +70,7 @@ impl Builder {
     /// use las::Builder;
     /// let builder = Builder::new(Default::default()).unwrap();
     /// ```
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(raw_header: raw::Header) -> Result<Builder> {
         use chrono::TimeZone;
         use utils::AsLasStr;

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -50,7 +50,6 @@ mod builder;
 
 pub use self::builder::Builder;
 
-use {Bounds, GpsTimeType, Point, Result, Transform, Vector, Version, Vlr, raw};
 use chrono::{Date, Datelike, Utc};
 use point::Format;
 use std::collections::HashMap;
@@ -58,6 +57,7 @@ use std::iter::Chain;
 use std::slice::Iter;
 use utils::FromLasStr;
 use uuid::Uuid;
+use {raw, Bounds, GpsTimeType, Point, Result, Transform, Vector, Version, Vlr};
 
 quick_error! {
     /// Header-specific errors.
@@ -200,7 +200,8 @@ impl Header {
     pub fn add_point(&mut self, point: &Point) {
         self.number_of_points += 1;
         if point.return_number > 0 {
-            let entry = self.number_of_points_by_return
+            let entry = self
+                .number_of_points_by_return
                 .entry(point.return_number)
                 .or_insert(0);
             *entry += 1;
@@ -401,7 +402,7 @@ impl Header {
     /// assert_eq!(None, header.number_of_points_by_return(1));
     /// ```
     pub fn number_of_points_by_return(&self, n: u8) -> Option<u64> {
-        self.number_of_points_by_return.get(&n).map(|&n| n)
+        self.number_of_points_by_return.get(&n).cloned()
     }
 
     /// Returns a reference to this header's vlr padding.
@@ -536,17 +537,17 @@ impl Header {
 
     fn system_identifier_raw(&self) -> Result<[u8; 32]> {
         let mut system_identifier = [0; 32];
-        system_identifier.as_mut().from_las_str(
-            &self.system_identifier,
-        )?;
+        system_identifier
+            .as_mut()
+            .from_las_str(&self.system_identifier)?;
         Ok(system_identifier)
     }
 
     fn generating_software_raw(&self) -> Result<[u8; 32]> {
         let mut generating_software = [0; 32];
-        generating_software.as_mut().from_las_str(
-            &self.generating_software,
-        )?;
+        generating_software
+            .as_mut()
+            .from_las_str(&self.generating_software)?;
         Ok(generating_software)
     }
 
@@ -585,16 +586,14 @@ impl Header {
     }
 
     fn number_of_points_raw(&self) -> Result<u32> {
-        use std::u32;
         use feature::LargeFiles;
+        use std::u32;
 
         if self.number_of_points > u64::from(u32::MAX) {
             if self.version.supports::<LargeFiles>() {
                 Ok(0)
             } else {
-                Err(
-                    Error::TooManyPoints(self.number_of_points, self.version).into(),
-                )
+                Err(Error::TooManyPoints(self.number_of_points, self.version).into())
             }
         } else {
             Ok(self.number_of_points as u32)
@@ -602,8 +601,8 @@ impl Header {
     }
 
     fn number_of_points_by_return_raw(&self) -> Result<[u32; 5]> {
-        use std::u32;
         use feature::LargeFiles;
+        use std::u32;
 
         let mut number_of_points_by_return = [0; 5];
         for (&i, &n) in &self.number_of_points_by_return {
@@ -633,8 +632,9 @@ impl Header {
         } else if n > u32::MAX as usize {
             Err(Error::TooManyEvlrs(n).into())
         } else {
-            let start_of_first_evlr = self.point_data_len() + self.point_padding.len() as u64 +
-                u64::from(self.offset_to_point_data()?);
+            let start_of_first_evlr = self.point_data_len()
+                + self.point_padding.len() as u64
+                + u64::from(self.offset_to_point_data()?);
             Ok(Some(raw::header::Evlr {
                 start_of_first_evlr: start_of_first_evlr,
                 number_of_evlrs: n as u32,
@@ -689,9 +689,9 @@ impl Default for Header {
 
 impl<V: Into<Version>> From<V> for Header {
     fn from(version: V) -> Header {
-        Builder::from(version).into_header().expect(
-            "Default builder could not be converted into a header",
-        )
+        Builder::from(version)
+            .into_header()
+            .expect("Default builder could not be converted into a header")
     }
 }
 
@@ -765,6 +765,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_lossless)]
     fn zero_legacy_fields_when_too_large() {
         use std::u32;
         let mut header = Header::from((1, 4));
@@ -799,6 +800,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_lossless)]
     fn number_of_points_large() {
         use std::u32;
 
@@ -820,21 +822,20 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_lossless)]
     fn number_of_points_by_return_large() {
         use std::u32;
 
         let mut header = Header::from((1, 2));
-        header.number_of_points_by_return.insert(
-            1,
-            u32::MAX as u64 + 1,
-        );
+        header
+            .number_of_points_by_return
+            .insert(1, u32::MAX as u64 + 1);
         assert!(header.into_raw().is_err());
 
         let mut header = Header::from((1, 4));
-        header.number_of_points_by_return.insert(
-            1,
-            u32::MAX as u64 + 1,
-        );
+        header
+            .number_of_points_by_return
+            .insert(1, u32::MAX as u64 + 1);
         let raw_header = header.into_raw().unwrap();
         assert_eq!(0, raw_header.number_of_points_by_return[0]);
         assert_eq!(
@@ -860,7 +861,8 @@ mod tests {
             padding: vec![0; u16::MAX as usize - 226],
             version: (1, 2).into(),
             ..Default::default()
-        }).unwrap();
+        })
+        .unwrap();
         assert!(builder.into_header().unwrap().into_raw().is_err());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,19 +104,25 @@
 //! writer.write(point).unwrap();
 //! ```
 
-#![deny(missing_docs,
-        missing_debug_implementations, missing_copy_implementations,
-        trivial_casts, trivial_numeric_casts,
+#![deny(
+        missing_docs,
+        missing_debug_implementations,
+        missing_copy_implementations,
+        trivial_casts,
+        trivial_numeric_casts,
         unsafe_code,
         unstable_features,
-        unused_import_braces, unused_qualifications)]
-#![recursion_limit="128"]
+        unused_import_braces,
+        unused_qualifications
+)]
+#![recursion_limit = "128"]
 
 extern crate byteorder;
 extern crate chrono;
 extern crate num;
 #[macro_use]
 extern crate quick_error;
+extern crate log;
 extern crate uuid;
 
 pub mod feature;
@@ -141,7 +147,7 @@ pub use color::Color;
 pub use error::Error;
 pub use feature::Feature;
 pub use gps_time_type::GpsTimeType;
-pub use header::{Header, Builder};
+pub use header::{Builder, Header};
 pub use point::Point;
 pub use reader::Reader;
 pub use transform::Transform;

--- a/src/point/classification.rs
+++ b/src/point/classification.rs
@@ -1,5 +1,5 @@
-use Result;
 use point::Error;
+use Result;
 
 /// The ASPRS classification table.
 ///
@@ -66,6 +66,7 @@ impl Classification {
     /// assert_eq!(Classification::Ground, Classification::new(2).unwrap());
     /// assert!(Classification::new(12).is_err());
     /// ```
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(n: u8) -> Result<Classification> {
         Ok(match n {
             0 => Classification::CreatedNeverClassified,
@@ -115,8 +116,7 @@ impl From<Classification> for u8 {
             Classification::WireStructureConnector => 16,
             Classification::BridgeDeck => 17,
             Classification::HighNoise => 18,
-            Classification::Reserved(n) |
-            Classification::UserDefinable(n) => n,
+            Classification::Reserved(n) | Classification::UserDefinable(n) => n,
         }
     }
 }

--- a/src/point/format.rs
+++ b/src/point/format.rs
@@ -2,10 +2,10 @@ use Result;
 use point::Error;
 use std::fmt;
 
-const TIME_FORMATS: &'static [u8] = &[1, 3, 4, 5, 6, 7, 8, 9, 10];
-const COLOR_FORMATS: &'static [u8] = &[2, 3, 5, 7, 8, 10];
-const WAVEFORM_FORMATS: &'static [u8] = &[4, 5, 9, 10];
-const NIR_FORMATS: &'static [u8] = &[8, 10];
+const TIME_FORMATS: &[u8] = &[1, 3, 4, 5, 6, 7, 8, 9, 10];
+const COLOR_FORMATS: &[u8] = &[2, 3, 5, 7, 8, 10];
+const WAVEFORM_FORMATS: &[u8] = &[4, 5, 9, 10];
+const NIR_FORMATS: &[u8] = &[8, 10];
 const IS_COMPRESSED_MASK: u8 = 0x80;
 
 /// Point formats are defined by the las spec.
@@ -60,7 +60,7 @@ pub struct Format {
     pub is_compressed: bool,
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]
+#[allow(clippy::len_without_is_empty)]
 impl Format {
     /// Creates a new point format from a u8.
     ///
@@ -124,7 +124,7 @@ impl Format {
     /// format.has_gps_time = true;
     /// assert_eq!(28, format.len());
     /// ```
-    pub fn len(&self) -> u16 {
+    pub fn len(self) -> u16 {
         let mut len = if self.is_extended { 22 } else { 20 } + self.extra_bytes;
         if self.has_gps_time {
             len += 8;
@@ -156,36 +156,36 @@ impl Format {
     /// format.has_gps_time = true;
     /// assert_eq!(6, format.to_u8().unwrap());
     /// ```
-    pub fn to_u8(&self) -> Result<u8> {
+    pub fn to_u8(self) -> Result<u8> {
         if self.is_compressed {
-            Err(Error::Format(*self).into())
+            Err(Error::Format(self).into())
         } else if self.is_extended {
             if self.has_gps_time {
                 if self.has_color {
                     if self.has_nir {
                         if self.has_waveform { Ok(10) } else { Ok(8) }
                     } else if self.has_waveform {
-                        Err(Error::Format(*self).into())
+                        Err(Error::Format(self).into())
                     } else {
                         Ok(7)
                     }
                 } else if self.has_nir {
-                    Err(Error::Format(*self).into())
+                    Err(Error::Format(self).into())
                 } else if self.has_waveform {
                     Ok(9)
                 } else {
                     Ok(6)
                 }
             } else {
-                Err(Error::Format(*self).into())
+                Err(Error::Format(self).into())
             }
         } else if self.has_nir {
-            Err(Error::Format(*self).into())
+            Err(Error::Format(self).into())
         } else if self.has_waveform {
             if self.has_gps_time {
                 if self.has_color { Ok(5) } else { Ok(4) }
             } else {
-                Err(Error::Format(*self).into())
+                Err(Error::Format(self).into())
             }
         } else {
             let mut n = if self.has_gps_time { 1 } else { 0 };

--- a/src/point/format.rs
+++ b/src/point/format.rs
@@ -78,6 +78,7 @@ impl Format {
     ///
     /// assert!(Format::new(11).is_err());
     /// ```
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(n: u8) -> Result<Format> {
         if n > 10 {
             Err(Error::FormatNumber(n).into())

--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -487,7 +487,7 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
-    fn write_read(header: Header) -> Result<()> {
+    fn write_read(header: &Header) -> Result<()> {
         let mut cursor = Cursor::new(Vec::new());
         header.write_to(&mut cursor).unwrap();
         cursor.set_position(0);
@@ -501,7 +501,7 @@ mod tests {
             file_signature: *b"ABCD",
             ..Default::default()
         };
-        assert!(write_read(header).is_err());
+        assert!(write_read(&header).is_err());
     }
 
     macro_rules! roundtrip {

--- a/src/raw/point.rs
+++ b/src/raw/point.rs
@@ -508,8 +508,8 @@ impl Flags {
     /// assert_eq!(1, Flags::TwoByte(1, 0).return_number());
     /// assert_eq!(1, Flags::ThreeByte(1, 0, 0).return_number());
     /// ```
-    pub fn return_number(&self) -> u8 {
-        match *self {
+    pub fn return_number(self) -> u8 {
+        match self {
             Flags::TwoByte(a, _) => a & 7,
             Flags::ThreeByte(a, _, _) => a & 15,
         }
@@ -524,8 +524,8 @@ impl Flags {
     /// assert_eq!(1, Flags::TwoByte(8, 0).number_of_returns());
     /// assert_eq!(1, Flags::ThreeByte(16, 0, 0).number_of_returns());
     /// ```
-    pub fn number_of_returns(&self) -> u8 {
-        match *self {
+    pub fn number_of_returns(self) -> u8 {
+        match self {
             Flags::TwoByte(a, _) => a >> 3 & 7,
             Flags::ThreeByte(a, _, _) => a >> 4 & 15,
         }
@@ -541,8 +541,8 @@ impl Flags {
     /// assert_eq!(ScanDirection::LeftToRight, Flags::TwoByte(0b01000000, 0).scan_direction());
     /// assert_eq!(ScanDirection::LeftToRight, Flags::ThreeByte(0, 0b01000000, 0).scan_direction());
     /// ```
-    pub fn scan_direction(&self) -> ScanDirection {
-        let n = match *self {
+    pub fn scan_direction(self) -> ScanDirection {
+        let n = match self {
             Flags::TwoByte(a, _) => a,
             Flags::ThreeByte(_, b, _) => b,
         };
@@ -562,8 +562,8 @@ impl Flags {
     /// assert!(Flags::TwoByte(0, 0b00100000).is_synthetic());
     /// assert!(Flags::ThreeByte(0, 1, 0).is_synthetic());
     /// ```
-    pub fn is_synthetic(&self) -> bool {
-        match *self {
+    pub fn is_synthetic(self) -> bool {
+        match self {
             Flags::TwoByte(_, b) => (b >> 5) & 1 == 1,
             Flags::ThreeByte(_, b, _) => b & 1 == 1,
         }
@@ -578,8 +578,8 @@ impl Flags {
     /// assert!(Flags::TwoByte(0, 0b01000000).is_key_point());
     /// assert!(Flags::ThreeByte(0, 2, 0).is_key_point());
     /// ```
-    pub fn is_key_point(&self) -> bool {
-        match *self {
+    pub fn is_key_point(self) -> bool {
+        match self {
             Flags::TwoByte(_, b) => (b >> 6) & 1 == 1,
             Flags::ThreeByte(_, b, _) => b & 2 == 2,
         }
@@ -594,8 +594,8 @@ impl Flags {
     /// assert!(Flags::TwoByte(0, 0b10000000).is_withheld());
     /// assert!(Flags::ThreeByte(0, 4, 0).is_withheld());
     /// ```
-    pub fn is_withheld(&self) -> bool {
-        match *self {
+    pub fn is_withheld(self) -> bool {
+        match self {
             Flags::TwoByte(_, b) => (b >> 7) & 1 == 1,
             Flags::ThreeByte(_, b, _) => b & 4 == 4,
         }
@@ -610,8 +610,8 @@ impl Flags {
     /// assert!(Flags::TwoByte(0, 12).is_overlap());
     /// assert!(Flags::ThreeByte(0, 8, 0).is_overlap());
     /// ```
-    pub fn is_overlap(&self) -> bool {
-        match *self {
+    pub fn is_overlap(self) -> bool {
+        match self {
             Flags::TwoByte(_, b) => b & 0b1111 == OVERLAP_CLASSIFICATION_CODE,
             Flags::ThreeByte(_, b, _) => b & 8 == 8,
         }
@@ -626,8 +626,8 @@ impl Flags {
     /// assert_eq!(0, Flags::TwoByte(0, 0).scanner_channel());
     /// assert_eq!(3, Flags::ThreeByte(0, 0b00110000, 0).scanner_channel());
     /// ```
-    pub fn scanner_channel(&self) -> u8 {
-        match *self {
+    pub fn scanner_channel(self) -> u8 {
+        match self {
             Flags::TwoByte(_, _) => 0,
             Flags::ThreeByte(_, b, _) => (b >> 4) & 3,
         }
@@ -642,8 +642,8 @@ impl Flags {
     /// assert!(Flags::TwoByte(128, 0).is_edge_of_flight_line());
     /// assert!(Flags::ThreeByte(0, 128, 0).is_edge_of_flight_line());
     /// ```
-    pub fn is_edge_of_flight_line(&self) -> bool {
-        let n = match *self {
+    pub fn is_edge_of_flight_line(self) -> bool {
+        let n = match self {
             Flags::TwoByte(a, _) => a,
             Flags::ThreeByte(_, b, _) => b,
         };
@@ -662,8 +662,8 @@ impl Flags {
     /// assert_eq!((1, 2), Flags::TwoByte(1, 2).to_two_bytes().unwrap());
     /// assert!(Flags::ThreeByte(0b00001000, 0, 0).to_two_bytes().is_err());
     /// ```
-    pub fn to_two_bytes(&self) -> Result<(u8, u8)> {
-        match *self {
+    pub fn to_two_bytes(self) -> Result<(u8, u8)> {
+        match self {
             Flags::TwoByte(a, b) => Ok((a, b)),
             Flags::ThreeByte(_, _, c) => {
                 if self.return_number() > 7 {
@@ -718,8 +718,8 @@ impl Flags {
     /// assert!(Flags::TwoByte(0, 12).to_classification().is_err());
     /// assert!(Flags::ThreeByte(0, 0, 12).to_classification().is_err());
     /// ```
-    pub fn to_classification(&self) -> Result<Classification> {
-        match *self {
+    pub fn to_classification(self) -> Result<Classification> {
+        match self {
             Flags::TwoByte(_, b) => Classification::new(b & 0b0001_1111),
             Flags::ThreeByte(_, _, c) => Classification::new(c),
         }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,5 +1,5 @@
-use Result;
 use std::fmt;
+use Result;
 
 /// A scale and an offset that transforms xyz coordinates.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -36,8 +36,8 @@ impl Transform {
     /// assert_eq!(1, transform.inverse(2.9).unwrap());
     /// ```
     pub fn inverse(&self, n: f64) -> Result<i32> {
-        use Error;
         use std::i32;
+        use Error;
 
         let n = ((n - self.offset) / self.scale).round();
         if n > f64::from(i32::MAX) || n < f64::from(i32::MIN) {
@@ -69,6 +69,7 @@ mod tests {
     use std::i32;
 
     #[test]
+    #[allow(clippy::cast_lossless)]
     fn too_large() {
         let transform = Transform::default();
         let n = i32::MAX as f64 * transform.scale + 1.;
@@ -76,6 +77,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_lossless)]
     fn too_small() {
         let transform = Transform::default();
         let n = i32::MIN as f64 * transform.scale - 1.;

--- a/src/version.rs
+++ b/src/version.rs
@@ -45,8 +45,8 @@ impl Version {
     /// assert!(Version::new(1, 0).requires_point_data_start_signature());
     /// assert!(!Version::new(1, 1).requires_point_data_start_signature());
     /// ```
-    pub fn requires_point_data_start_signature(&self) -> bool {
-        self == &Version::new(1, 0)
+    pub fn requires_point_data_start_signature(self) -> bool {
+        self == Version::new(1, 0)
     }
 
     /// Returns this version's header size.
@@ -59,10 +59,10 @@ impl Version {
     /// assert_eq!(235, Version::new(1, 3).header_size());
     /// assert_eq!(375, Version::new(1, 4).header_size());
     /// ```
-    pub fn header_size(&self) -> u16 {
-        if self <= &Version::new(1, 2) {
+    pub fn header_size(self) -> u16 {
+        if self <= Version::new(1, 2) {
             227
-        } else if self == &Version::new(1, 3) {
+        } else if self == Version::new(1, 3) {
             235
         } else {
             375
@@ -79,11 +79,11 @@ impl Version {
     /// Version::new(1, 4).verify_support_for::<Waveforms>().unwrap();
     /// assert!(Version::new(1, 2).verify_support_for::<Waveforms>().is_err());
     /// ```
-    pub fn verify_support_for<F: Feature>(&self) -> Result<()> {
+    pub fn verify_support_for<F: Feature>(self) -> Result<()> {
         if self.supports::<F>() {
             Ok(())
         } else {
-            Err(Error::Feature(*self, F::name()))
+            Err(Error::Feature(self, F::name()))
         }
     }
 
@@ -97,8 +97,8 @@ impl Version {
     /// assert!(Version::new(1, 4).supports::<Waveforms>());
     /// assert!(!Version::new(1, 2).supports::<Waveforms>());
     /// ```
-    pub fn supports<F: Feature>(&self) -> bool {
-        F::is_supported_by(*self)
+    pub fn supports<F: Feature>(self) -> bool {
+        F::is_supported_by(self)
     }
 
     /// Checks whether this version supports the given point format.
@@ -114,7 +114,7 @@ impl Version {
     /// assert!(!las_1_2.supports_point_format(Format::new(4).unwrap()));
     /// assert!(las_1_4.supports_point_format(Format::new(4).unwrap()));
     /// ```
-    pub fn supports_point_format(&self, format: Format) -> bool {
+    pub fn supports_point_format(self, format: Format) -> bool {
         if self.major != 1 {
             return false;
         }

--- a/src/vlr.rs
+++ b/src/vlr.rs
@@ -29,7 +29,7 @@
 //! assert_eq!(1, header.vlrs().len());
 //! ```
 
-use {Result, raw};
+use {raw, Result};
 
 const REGULAR_HEADER_SIZE: usize = 54;
 const EXTENDED_HEADER_SIZE: usize = 60;
@@ -75,6 +75,7 @@ impl Vlr {
     /// let raw_vlr = raw::Vlr::default();
     /// let vlr = Vlr::new(raw_vlr).unwrap();
     /// ```
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(raw_vlr: raw::Vlr) -> Result<Vlr> {
         use utils::AsLasStr;
         Ok(Vlr {
@@ -125,8 +126,8 @@ impl Vlr {
     /// assert_eq!(55, vlr.len(false));
     /// ```
     pub fn len(&self, is_extended: bool) -> usize {
-        self.data.len() +
-            if is_extended {
+        self.data.len()
+            + if is_extended {
                 EXTENDED_HEADER_SIZE
             } else {
                 REGULAR_HEADER_SIZE


### PR DESCRIPTION
This should help fix lints for people using the RLS' clippy support by either fixing the lint or allowing it on a per-lint basis. Some `&self` were changed to `self`, so this might include breaking changes. Let me know if you need any of this to be adjusted.