### PR TITLE
Add Reader and Writer traits. Rename existing structs with Std prefix.

### DIFF
--- a/benches/roundtrip.rs
+++ b/benches/roundtrip.rs
@@ -3,7 +3,7 @@
 extern crate las;
 extern crate test;
 
-use las::{Point, Reader, Writer};
+use las::{Point, Read, Reader, Write, Writer};
 use test::Bencher;
 
 fn roundtrip(npoints: usize) {

--- a/benches/roundtrip.rs
+++ b/benches/roundtrip.rs
@@ -3,15 +3,15 @@
 extern crate las;
 extern crate test;
 
-use las::{Point, Reader, Writer};
+use las::{Point, Reader, StdReader, Writer, StdWriter};
 use test::Bencher;
 
 fn roundtrip(npoints: usize) {
-    let mut writer = Writer::default();
+    let mut writer = StdWriter::default();
     for _ in 0..npoints {
         writer.write(Point::default()).unwrap();
     }
-    let mut reader = Reader::new(writer.into_inner().unwrap()).unwrap();
+    let mut reader = StdReader::new(writer.into_inner().unwrap()).unwrap();
     for point in reader.points() {
         let _ = point.unwrap();
     }

--- a/benches/roundtrip.rs
+++ b/benches/roundtrip.rs
@@ -3,15 +3,15 @@
 extern crate las;
 extern crate test;
 
-use las::{Point, Reader, StdReader, Writer, StdWriter};
+use las::{Point, Reader, Writer};
 use test::Bencher;
 
 fn roundtrip(npoints: usize) {
-    let mut writer = StdWriter::default();
+    let mut writer = Writer::default();
     for _ in 0..npoints {
         writer.write(Point::default()).unwrap();
     }
-    let mut reader = StdReader::new(writer.into_inner().unwrap()).unwrap();
+    let mut reader = Reader::new(writer.into_inner().unwrap()).unwrap();
     for point in reader.points() {
         let _ = point.unwrap();
     }

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -2,14 +2,14 @@
 
 extern crate las;
 
-use las::{Reader, StdReader};
+use las::Reader;
 
 fn main() {
     let path = std::env::args()
         .skip(1)
         .next()
         .expect("Must provide a path to a las file");
-    let mut reader = StdReader::from_path(path).expect("Unable to open reader");
+    let mut reader = Reader::from_path(path).expect("Unable to open reader");
     let npoints = reader
         .points()
         .map(|p| p.expect("Unable to read point"))

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -2,7 +2,7 @@
 
 extern crate las;
 
-use las::Reader;
+use las::{Read, Reader};
 
 fn main() {
     let path = std::env::args()

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -2,14 +2,14 @@
 
 extern crate las;
 
-use las::Reader;
+use las::{Reader, StdReader};
 
 fn main() {
     let path = std::env::args()
         .skip(1)
         .next()
         .expect("Must provide a path to a las file");
-    let mut reader = Reader::from_path(path).expect("Unable to open reader");
+    let mut reader = StdReader::from_path(path).expect("Unable to open reader");
     let npoints = reader
         .points()
         .map(|p| p.expect("Unable to read point"))

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -5,33 +5,33 @@
 //! A `Reader` uses a `Header` to expose metadata:
 //!
 //! ```
-//! use las::{Reader, StdReader};
-//! let reader = StdReader::from_path("tests/data/autzen.las").unwrap();
+//! use las::Reader;
+//! let reader = Reader::from_path("tests/data/autzen.las").unwrap();
 //! let header = reader.header();
 //! println!("The file has {} points.", header.number_of_points());
 //! ```
 //!
 //! # Writing
 //!
-//! A `StdWriter` uses a header to configure how it will write points.  To create a las file, you can
+//! A `Writer` uses a header to configure how it will write points.  To create a las file, you can
 //! use a `Header` from another file, use the default `Header`, or create one with a `Builder`:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{StdWriter, Builder, Reader, StdReader, Header};
+//! use las::{Writer, Builder, Reader, Header};
 //!
 //! // Copy the configuration from an existing file.
-//! let header = StdReader::from_path("tests/data/autzen.las").unwrap().header().clone();
-//! let writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
+//! let header = Reader::from_path("tests/data/autzen.las").unwrap().header().clone();
+//! let writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
 //!
 //! // Use the default configuration, which writes to a `Cursor<Vec<u8>>`.
-//! let writer = StdWriter::default();
+//! let writer = Writer::default();
 //!
 //! // Set your own configuration with a `Builder`.
 //! let mut builder = Builder::from((1, 4));
 //! builder.system_identifier = "Synthetic points".to_string();
 //! let header = builder.into_header().unwrap();
-//! let writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
+//! let writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
 //! ```
 //!
 //! # Into raw bytes

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -5,33 +5,33 @@
 //! A `Reader` uses a `Header` to expose metadata:
 //!
 //! ```
-//! use las::Reader;
-//! let reader = Reader::from_path("tests/data/autzen.las").unwrap();
+//! use las::{Reader, StdReader};
+//! let reader = StdReader::from_path("tests/data/autzen.las").unwrap();
 //! let header = reader.header();
 //! println!("The file has {} points.", header.number_of_points());
 //! ```
 //!
 //! # Writing
 //!
-//! A `Writer` uses a header to configure how it will write points.  To create a las file, you can
+//! A `StdWriter` uses a header to configure how it will write points.  To create a las file, you can
 //! use a `Header` from another file, use the default `Header`, or create one with a `Builder`:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Builder, Reader, Header};
+//! use las::{StdWriter, Builder, Reader, StdReader, Header};
 //!
 //! // Copy the configuration from an existing file.
-//! let header = Reader::from_path("tests/data/autzen.las").unwrap().header().clone();
-//! let writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
+//! let header = StdReader::from_path("tests/data/autzen.las").unwrap().header().clone();
+//! let writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
 //!
 //! // Use the default configuration, which writes to a `Cursor<Vec<u8>>`.
-//! let writer = Writer::default();
+//! let writer = StdWriter::default();
 //!
 //! // Set your own configuration with a `Builder`.
 //! let mut builder = Builder::from((1, 4));
 //! builder.system_identifier = "Synthetic points".to_string();
 //! let header = builder.into_header().unwrap();
-//! let writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
+//! let writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
 //! ```
 //!
 //! # Into raw bytes

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -5,7 +5,7 @@
 //! A `Reader` uses a `Header` to expose metadata:
 //!
 //! ```
-//! use las::Reader;
+//! use las::{Read, Reader};
 //! let reader = Reader::from_path("tests/data/autzen.las").unwrap();
 //! let header = reader.header();
 //! println!("The file has {} points.", header.number_of_points());
@@ -18,7 +18,7 @@
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Builder, Reader, Header};
+//! use las::{Write, Writer, Builder, Read, Reader, Header};
 //!
 //! // Copy the configuration from an existing file.
 //! let header = Reader::from_path("tests/data/autzen.las").unwrap().header().clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@
 //!
 //! # Reading
 //!
-//! Create a `Reader` from a `Path`:
+//! Create an object that implements `Reader` from a `Path`:
 //!
 //! ```
-//! use las::Reader;
-//! let reader = Reader::from_path("tests/data/autzen.las").unwrap();
+//! use las::StdReader;
+//! let reader = StdReader::from_path("tests/data/autzen.las").unwrap();
 //! ```
 //!
 //! Or anything that implements `Read`:
@@ -15,9 +15,9 @@
 //! ```
 //! use std::io::BufReader;
 //! use std::fs::File;
-//! use las::Reader;
+//! use las::StdReader;
 //! let read = BufReader::new(File::open("tests/data/autzen.las").unwrap());
-//! let reader = Reader::new(read).unwrap();
+//! let reader = StdReader::new(read).unwrap();
 //! ```
 //!
 //! ## Prefer `BufRead`
@@ -30,16 +30,16 @@
 //! Read points one-by-one with `Reader::read`:
 //!
 //! ```
-//! use las::Reader;
-//! let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
+//! use las::{Reader, StdReader};
+//! let mut reader = StdReader::from_path("tests/data/autzen.las").unwrap();
 //! let point = reader.read().unwrap().unwrap();
 //! ```
 //!
 //! Or iterate over all points with `Reader::points`:
 //!
 //! ```
-//! use las::Reader;
-//! let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
+//! use las::{Reader, StdReader};
+//! let mut reader = StdReader::from_path("tests/data/autzen.las").unwrap();
 //! for wrapped_point in reader.points() {
 //!     let point = wrapped_point.unwrap();
 //!     println!("Point coordinates: ({}, {}, {})", point.x, point.y, point.z);
@@ -55,28 +55,28 @@
 //!
 //! # Writing
 //!
-//! Create a `Writer` from a `Write` and a `Header`:
+//! Create a `StdWriter` from a `Write` and a `Header`:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Header};
+//! use las::{StdWriter, Header};
 //! let write = Cursor::new(Vec::new());
 //! let header = Header::default();
-//! let writer = Writer::new(write, header).unwrap();
+//! let writer = StdWriter::new(write, header).unwrap();
 //! ```
 //!
-//! You can also write out to a path (automatically buffered with `BufWriter`):
+//! You can also write out to a path (automatically buffered with `BufStdWriter`):
 //!
 //! ```
-//! use las::Writer;
-//! let writer = Writer::from_path("/dev/null", Default::default());
+//! use las::StdWriter;
+//! let writer = StdWriter::from_path("/dev/null", Default::default());
 //! ```
 //!
 //! Use a `Builder` to customize the las data:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Builder};
+//! use las::{StdWriter, Builder};
 //! use las::point::Format;
 //!
 //! let mut builder = Builder::from((1, 4));
@@ -84,14 +84,14 @@
 //! let header = builder.into_header().unwrap();
 //!
 //! let write = Cursor::new(Vec::new());
-//! let writer = Writer::new(write, header).unwrap();
+//! let writer = StdWriter::new(write, header).unwrap();
 //! ```
 //!
 //! If compiled with laz you can compress the data written
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Builder};
+//! use las::{StdWriter, Builder};
 //! use las::point::Format;
 //!
 //! let mut builder = Builder::from((1, 4));
@@ -104,7 +104,7 @@
 //! let is_compiled_with_laz = cfg!(feature = "laz");
 //!
 //!
-//! let result =  Writer::new(write, header);
+//! let result =  StdWriter::new(write, header);
 //! if is_compiled_with_laz {
 //!     assert_eq!(result.is_ok(), true);
 //! } else {
@@ -113,7 +113,7 @@
 //!
 //! ```
 //!
-//! The [from_path](writer/struct.Writer.html#method.from_path) will use the extension of the output
+//! The [from_path](writer/struct.StdWriter.html#method.from_path) will use the extension of the output
 //! file to determine wether the data should be compressed or not
 //! 'laz' => compressed
 //! 'las' => not compressed
@@ -129,8 +129,8 @@
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Point};
-//! let mut writer = Writer::default();
+//! use las::{StdWriter, Writer, Point};
+//! let mut writer = StdWriter::default();
 //! let point = Point { x: 1., y: 2., z: 3., ..Default::default() };
 //! writer.write(point).unwrap();
 //! ```
@@ -185,12 +185,12 @@ pub use feature::Feature;
 pub use gps_time_type::GpsTimeType;
 pub use header::{Builder, Header};
 pub use point::Point;
-pub use reader::Reader;
+pub use reader::{Reader, StdReader};
 pub use transform::Transform;
 pub use vector::Vector;
 pub use version::Version;
 pub use vlr::Vlr;
-pub use writer::Writer;
+pub use writer::{StdWriter, Writer};
 
 /// Crate-specific result type.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! Read points one-by-one with `Reader::read`:
 //!
 //! ```
-//! use las::Reader;
+//! use las::{Read, Reader};
 //! let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
 //! let point = reader.read().unwrap().unwrap();
 //! ```
@@ -38,7 +38,7 @@
 //! Or iterate over all points with `Reader::points`:
 //!
 //! ```
-//! use las::Reader;
+//! use las::{Read, Reader};
 //! let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
 //! for wrapped_point in reader.points() {
 //!     let point = wrapped_point.unwrap();
@@ -129,7 +129,7 @@
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Point};
+//! use las::{Write, Writer, Point};
 //! let mut writer = Writer::default();
 //! let point = Point { x: 1., y: 2., z: 3., ..Default::default() };
 //! writer.write(point).unwrap();
@@ -185,12 +185,12 @@ pub use feature::Feature;
 pub use gps_time_type::GpsTimeType;
 pub use header::{Builder, Header};
 pub use point::Point;
-pub use reader::Reader;
+pub use reader::{Read, Reader};
 pub use transform::Transform;
 pub use vector::Vector;
 pub use version::Version;
 pub use vlr::Vlr;
-pub use writer::Writer;
+pub use writer::{Write, Writer};
 
 /// Crate-specific result type.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@
 //!
 //! # Reading
 //!
-//! Create an object that implements `Reader` from a `Path`:
+//! Create a `Reader` from a `Path`:
 //!
 //! ```
-//! use las::StdReader;
-//! let reader = StdReader::from_path("tests/data/autzen.las").unwrap();
+//! use las::Reader;
+//! let reader = Reader::from_path("tests/data/autzen.las").unwrap();
 //! ```
 //!
 //! Or anything that implements `Read`:
@@ -15,9 +15,9 @@
 //! ```
 //! use std::io::BufReader;
 //! use std::fs::File;
-//! use las::StdReader;
+//! use las::Reader;
 //! let read = BufReader::new(File::open("tests/data/autzen.las").unwrap());
-//! let reader = StdReader::new(read).unwrap();
+//! let reader = Reader::new(read).unwrap();
 //! ```
 //!
 //! ## Prefer `BufRead`
@@ -30,16 +30,16 @@
 //! Read points one-by-one with `Reader::read`:
 //!
 //! ```
-//! use las::{Reader, StdReader};
-//! let mut reader = StdReader::from_path("tests/data/autzen.las").unwrap();
+//! use las::Reader;
+//! let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
 //! let point = reader.read().unwrap().unwrap();
 //! ```
 //!
 //! Or iterate over all points with `Reader::points`:
 //!
 //! ```
-//! use las::{Reader, StdReader};
-//! let mut reader = StdReader::from_path("tests/data/autzen.las").unwrap();
+//! use las::Reader;
+//! let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
 //! for wrapped_point in reader.points() {
 //!     let point = wrapped_point.unwrap();
 //!     println!("Point coordinates: ({}, {}, {})", point.x, point.y, point.z);
@@ -55,28 +55,28 @@
 //!
 //! # Writing
 //!
-//! Create a `StdWriter` from a `Write` and a `Header`:
+//! Create a `Writer` from a `Write` and a `Header`:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{StdWriter, Header};
+//! use las::{Writer, Header};
 //! let write = Cursor::new(Vec::new());
 //! let header = Header::default();
-//! let writer = StdWriter::new(write, header).unwrap();
+//! let writer = Writer::new(write, header).unwrap();
 //! ```
 //!
-//! You can also write out to a path (automatically buffered with `BufStdWriter`):
+//! You can also write out to a path (automatically buffered with `BufWriter`):
 //!
 //! ```
-//! use las::StdWriter;
-//! let writer = StdWriter::from_path("/dev/null", Default::default());
+//! use las::Writer;
+//! let writer = Writer::from_path("/dev/null", Default::default());
 //! ```
 //!
 //! Use a `Builder` to customize the las data:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{StdWriter, Builder};
+//! use las::{Writer, Builder};
 //! use las::point::Format;
 //!
 //! let mut builder = Builder::from((1, 4));
@@ -84,14 +84,14 @@
 //! let header = builder.into_header().unwrap();
 //!
 //! let write = Cursor::new(Vec::new());
-//! let writer = StdWriter::new(write, header).unwrap();
+//! let writer = Writer::new(write, header).unwrap();
 //! ```
 //!
 //! If compiled with laz you can compress the data written
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{StdWriter, Builder};
+//! use las::{Writer, Builder};
 //! use las::point::Format;
 //!
 //! let mut builder = Builder::from((1, 4));
@@ -104,7 +104,7 @@
 //! let is_compiled_with_laz = cfg!(feature = "laz");
 //!
 //!
-//! let result =  StdWriter::new(write, header);
+//! let result =  Writer::new(write, header);
 //! if is_compiled_with_laz {
 //!     assert_eq!(result.is_ok(), true);
 //! } else {
@@ -113,7 +113,7 @@
 //!
 //! ```
 //!
-//! The [from_path](writer/struct.StdWriter.html#method.from_path) will use the extension of the output
+//! The [from_path](writer/struct.Writer.html#method.from_path) will use the extension of the output
 //! file to determine wether the data should be compressed or not
 //! 'laz' => compressed
 //! 'las' => not compressed
@@ -129,8 +129,8 @@
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{StdWriter, Writer, Point};
-//! let mut writer = StdWriter::default();
+//! use las::{Writer, Point};
+//! let mut writer = Writer::default();
 //! let point = Point { x: 1., y: 2., z: 3., ..Default::default() };
 //! writer.write(point).unwrap();
 //! ```
@@ -185,12 +185,12 @@ pub use feature::Feature;
 pub use gps_time_type::GpsTimeType;
 pub use header::{Builder, Header};
 pub use point::Point;
-pub use reader::{Reader, StdReader};
+pub use reader::Reader;
 pub use transform::Transform;
 pub use vector::Vector;
 pub use version::Version;
 pub use vlr::Vlr;
-pub use writer::{StdWriter, Writer};
+pub use writer::Writer;
 
 /// Crate-specific result type.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,25 +1,25 @@
 //! Write las points.
 //!
-//! A `StdWriter` uses a `Header` for its configuration:
+//! A `Writer` uses a `Header` for its configuration:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{StdWriter, Header};
+//! use las::{Writer, Header};
 //! let mut header = Header::from((1, 4));
-//! let writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
+//! let writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
 //! ```
 //!
 //! The set of optional fields on the point format and the points must match exactly:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Builder, StdWriter, Writer, Point};
+//! use las::{Builder, Writer, Point};
 //! use las::point::Format;
 //! use las::Color;
 //!
 //! let mut builder = Builder::default();
 //! builder.point_format = Format::new(1).unwrap();
-//! let mut writer = StdWriter::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
+//! let mut writer = Writer::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
 //!
 //! let mut point = Point::default(); // default points don't have any optional attributes
 //! assert!(writer.write(point.clone()).is_err());
@@ -163,35 +163,6 @@ pub(crate) fn write_header_and_vlrs_to<W: Write>(mut dest: &mut W, header: &Head
 
 /// Writes LAS data.
 ///
-/// See StdWriter for a concrete implementation.
-pub trait Writer {
-    /// Returns a reference to this writer's header.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use las::{StdWriter, Writer};
-    /// let writer = StdWriter::default();
-    /// let header = writer.header();
-    /// ```
-    fn header(&self) -> &Header;
-
-    /// Writes a point
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::io::Cursor;
-    /// use las::{StdWriter, Writer};
-    ///
-    /// let mut writer = StdWriter::default();
-    /// writer.write(Default::default()).unwrap();
-    /// ```
-    fn write(&mut self, point: Point) -> Result<()>;
-}
-
-/// Writes LAS data.
-///
 /// The LAS header needs to be re-written when the writer closes. For convenience, this is done via
 /// the `Drop` implementation of the writer. One consequence is that if the header re-write fails
 /// during the drop, a panic will result. If you want to check for errors instead of panicing, use
@@ -199,20 +170,20 @@ pub trait Writer {
 ///
 /// ```
 /// use std::io::Cursor;
-/// use las::StdWriter;
+/// use las::Writer;
 /// {
-///     let mut writer = StdWriter::default();
+///     let mut writer = Writer::default();
 ///     writer.close().unwrap();
 /// } // <- `close` is not called
 /// ```
 #[derive(Debug)]
-pub struct StdWriter<W: 'static + Write + Seek + Debug> {
+pub struct Writer<W: 'static + Write + Seek + Debug> {
     closed: bool,
     start: u64,
     point_writer: Box<dyn PointWriter<W>>,
 }
 
-impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
+impl<W: 'static + Write + Seek + Debug> Writer<W> {
     /// Creates a new writer.
     ///
     /// The header that is passed in will have various fields zero'd, e.g. bounds, number of
@@ -222,8 +193,8 @@ impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
     ///
     /// ```
     /// use std::io::Cursor;
-    /// use las::StdWriter;
-    /// let writer = StdWriter::new(Cursor::new(Vec::new()), Default::default());
+    /// use las::Writer;
+    /// let writer = Writer::new(Cursor::new(Vec::new()), Default::default());
     /// ```
     pub fn new(mut dest: W, mut header: Header) -> Result<Self> {
         let start = dest.seek(SeekFrom::Current(0))?;
@@ -249,12 +220,46 @@ impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
         #[cfg(not(feature = "laz"))]
         {
             write_header_and_vlrs_to(&mut dest, &header)?;
-            Ok(StdWriter {
+            Ok(Writer {
                 closed: false,
                 start,
                 point_writer: Box::new(UncompressedPointWriter { dest, header }),
             })
         }
+    }
+
+    /// Returns a reference to this writer's header.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use las::Writer;
+    /// let writer = Writer::default();
+    /// let header = writer.header();
+    /// ```
+    pub fn header(&self) -> &Header {
+        &self.point_writer.header()
+    }
+
+    /// Writes a point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::Cursor;
+    /// use las::Writer;
+    ///
+    /// let mut writer = Writer::default();
+    /// writer.write(Default::default()).unwrap();
+    /// ```
+    pub fn write(&mut self, point: Point) -> Result<()> {
+        if self.closed {
+            return Err(Error::Closed.into());
+        }
+        if !point.matches(self.header().point_format()) {
+            return Err(Error::PointAttributes(*self.header().point_format(), point).into());
+        }
+        self.point_writer.write_next(point)
     }
 
     /// Close this writer.
@@ -263,8 +268,8 @@ impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
     ///
     /// ```
     /// use std::io::Cursor;
-    /// use las::StdWriter;
-    /// let mut writer = StdWriter::default();
+    /// use las::Writer;
+    /// let mut writer = Writer::default();
     /// writer.close().unwrap();
     /// assert!(writer.close().is_err());
     /// ```
@@ -305,32 +310,14 @@ impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
     }
 }
 
-impl<W: 'static + Write + Seek + Debug> Writer for StdWriter<W> {
-    /// Returns the header.
-    fn header(&self) -> &Header {
-        &self.point_writer.header()
-    }
-
-    /// Writes a point.
-    fn write(&mut self, point: Point) -> Result<()> {
-        if self.closed {
-            return Err(Error::Closed.into());
-        }
-        if !point.matches(self.header().point_format()) {
-            return Err(Error::PointAttributes(*self.header().point_format(), point).into());
-        }
-        self.point_writer.write_next(point)
-    }
-}
-
-impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
+impl<W: 'static + Write + Seek + Debug> Writer<W> {
     /// Closes this writer and returns its inner `Write`, seeked to the beginning of the las data.
     ///
     /// # Examples
     ///
     /// ```
-    /// use las::StdWriter;
-    /// let writer = StdWriter::default();
+    /// use las::Writer;
+    /// let writer = Writer::default();
     /// let cursor = writer.into_inner().unwrap();
     /// ```
     pub fn into_inner(mut self) -> Result<W> {
@@ -353,7 +340,7 @@ impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
     }
 }
 
-impl StdWriter<BufWriter<File>> {
+impl Writer<BufWriter<File>> {
     /// Creates a new writer for a path.
     ///
     /// If the "laz" feature is enabled, guesses from the extension if the
@@ -362,13 +349,13 @@ impl StdWriter<BufWriter<File>> {
     /// # Examples
     ///
     /// ```
-    /// use las::StdWriter;
-    /// let writer = StdWriter::from_path("/dev/null", Default::default());
+    /// use las::Writer;
+    /// let writer = Writer::from_path("/dev/null", Default::default());
     /// ```
     pub fn from_path<P: AsRef<Path>>(
         path: P,
         mut header: Header,
-    ) -> Result<StdWriter<BufWriter<File>>> {
+    ) -> Result<Writer<BufWriter<File>>> {
         let compress = if cfg!(feature = "laz") {
             match path.as_ref().extension() {
                 Some(ext) => match &ext.to_str() {
@@ -390,17 +377,17 @@ impl StdWriter<BufWriter<File>> {
         header.point_format_mut().is_compressed = compress;
         File::create(path)
             .map_err(::Error::from)
-            .and_then(|file| StdWriter::new(BufWriter::new(file), header))
+            .and_then(|file| Writer::new(BufWriter::new(file), header))
     }
 }
 
-impl Default for StdWriter<Cursor<Vec<u8>>> {
-    fn default() -> StdWriter<Cursor<Vec<u8>>> {
-        StdWriter::new(Cursor::new(Vec::new()), Header::default()).unwrap()
+impl Default for Writer<Cursor<Vec<u8>>> {
+    fn default() -> Writer<Cursor<Vec<u8>>> {
+        Writer::new(Cursor::new(Vec::new()), Header::default()).unwrap()
     }
 }
 
-impl<W: 'static + Seek + Write + Debug> Drop for StdWriter<W> {
+impl<W: 'static + Seek + Write + Debug> Drop for Writer<W> {
     fn drop(&mut self) {
         if !self.closed {
             self.close().expect("Error when dropping the writer");
@@ -418,16 +405,16 @@ mod tests {
 
     use super::*;
 
-    fn writer(format: Format, version: Version) -> StdWriter<Cursor<Vec<u8>>> {
+    fn writer(format: Format, version: Version) -> Writer<Cursor<Vec<u8>>> {
         let mut builder = Builder::default();
         builder.point_format = format;
         builder.version = version;
-        StdWriter::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap()
+        Writer::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap()
     }
 
     #[test]
     fn already_closed() {
-        let mut writer = StdWriter::default();
+        let mut writer = Writer::default();
         writer.close().unwrap();
         assert!(writer.close().is_err());
         assert!(writer.write(Default::default()).is_err());
@@ -479,14 +466,14 @@ mod tests {
     #[test]
     fn write_not_at_start() {
         use byteorder::WriteBytesExt;
-        use {Reader, StdReader};
+        use Reader;
 
         let mut cursor = Cursor::new(Vec::new());
         cursor.write_u8(42).unwrap();
-        let mut writer = StdWriter::new(cursor, Default::default()).unwrap();
+        let mut writer = Writer::new(cursor, Default::default()).unwrap();
         let point = Point::default();
         writer.write(point.clone()).unwrap();
-        let mut reader = StdReader::new(writer.into_inner().unwrap()).unwrap();
+        let mut reader = Reader::new(writer.into_inner().unwrap()).unwrap();
         assert_eq!(point, reader.read().unwrap().unwrap());
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,25 +1,25 @@
 //! Write las points.
 //!
-//! A `Writer` uses a `Header` for its configuration:
+//! A `StdWriter` uses a `Header` for its configuration:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Writer, Header};
+//! use las::{StdWriter, Header};
 //! let mut header = Header::from((1, 4));
-//! let writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
+//! let writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
 //! ```
 //!
 //! The set of optional fields on the point format and the points must match exactly:
 //!
 //! ```
 //! use std::io::Cursor;
-//! use las::{Builder, Writer, Point};
+//! use las::{Builder, StdWriter, Writer, Point};
 //! use las::point::Format;
 //! use las::Color;
 //!
 //! let mut builder = Builder::default();
 //! builder.point_format = Format::new(1).unwrap();
-//! let mut writer = Writer::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
+//! let mut writer = StdWriter::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
 //!
 //! let mut point = Point::default(); // default points don't have any optional attributes
 //! assert!(writer.write(point.clone()).is_err());
@@ -163,6 +163,35 @@ pub(crate) fn write_header_and_vlrs_to<W: Write>(mut dest: &mut W, header: &Head
 
 /// Writes LAS data.
 ///
+/// See StdWriter for a concrete implementation.
+pub trait Writer {
+    /// Returns a reference to this writer's header.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use las::{StdWriter, Writer};
+    /// let writer = StdWriter::default();
+    /// let header = writer.header();
+    /// ```
+    fn header(&self) -> &Header;
+
+    /// Writes a point
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::Cursor;
+    /// use las::{StdWriter, Writer};
+    ///
+    /// let mut writer = StdWriter::default();
+    /// writer.write(Default::default()).unwrap();
+    /// ```
+    fn write(&mut self, point: Point) -> Result<()>;
+}
+
+/// Writes LAS data.
+///
 /// The LAS header needs to be re-written when the writer closes. For convenience, this is done via
 /// the `Drop` implementation of the writer. One consequence is that if the header re-write fails
 /// during the drop, a panic will result. If you want to check for errors instead of panicing, use
@@ -170,20 +199,20 @@ pub(crate) fn write_header_and_vlrs_to<W: Write>(mut dest: &mut W, header: &Head
 ///
 /// ```
 /// use std::io::Cursor;
-/// use las::Writer;
+/// use las::StdWriter;
 /// {
-///     let mut writer = Writer::default();
+///     let mut writer = StdWriter::default();
 ///     writer.close().unwrap();
 /// } // <- `close` is not called
 /// ```
 #[derive(Debug)]
-pub struct Writer<W: 'static + Write + Seek + Debug> {
+pub struct StdWriter<W: 'static + Write + Seek + Debug> {
     closed: bool,
     start: u64,
     point_writer: Box<dyn PointWriter<W>>,
 }
 
-impl<W: 'static + Write + Seek + Debug> Writer<W> {
+impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
     /// Creates a new writer.
     ///
     /// The header that is passed in will have various fields zero'd, e.g. bounds, number of
@@ -193,8 +222,8 @@ impl<W: 'static + Write + Seek + Debug> Writer<W> {
     ///
     /// ```
     /// use std::io::Cursor;
-    /// use las::Writer;
-    /// let writer = Writer::new(Cursor::new(Vec::new()), Default::default());
+    /// use las::StdWriter;
+    /// let writer = StdWriter::new(Cursor::new(Vec::new()), Default::default());
     /// ```
     pub fn new(mut dest: W, mut header: Header) -> Result<Self> {
         let start = dest.seek(SeekFrom::Current(0))?;
@@ -220,46 +249,12 @@ impl<W: 'static + Write + Seek + Debug> Writer<W> {
         #[cfg(not(feature = "laz"))]
         {
             write_header_and_vlrs_to(&mut dest, &header)?;
-            Ok(Writer {
+            Ok(StdWriter {
                 closed: false,
                 start,
                 point_writer: Box::new(UncompressedPointWriter { dest, header }),
             })
         }
-    }
-
-    /// Returns a reference to this writer's header.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use las::Writer;
-    /// let writer = Writer::default();
-    /// let header = writer.header();
-    /// ```
-    pub fn header(&self) -> &Header {
-        &self.point_writer.header()
-    }
-
-    /// Writes a point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::io::Cursor;
-    /// use las::Writer;
-    ///
-    /// let mut writer = Writer::default();
-    /// writer.write(Default::default()).unwrap();
-    /// ```
-    pub fn write(&mut self, point: Point) -> Result<()> {
-        if self.closed {
-            return Err(Error::Closed.into());
-        }
-        if !point.matches(self.header().point_format()) {
-            return Err(Error::PointAttributes(*self.header().point_format(), point).into());
-        }
-        self.point_writer.write_next(point)
     }
 
     /// Close this writer.
@@ -268,8 +263,8 @@ impl<W: 'static + Write + Seek + Debug> Writer<W> {
     ///
     /// ```
     /// use std::io::Cursor;
-    /// use las::Writer;
-    /// let mut writer = Writer::default();
+    /// use las::StdWriter;
+    /// let mut writer = StdWriter::default();
     /// writer.close().unwrap();
     /// assert!(writer.close().is_err());
     /// ```
@@ -310,14 +305,32 @@ impl<W: 'static + Write + Seek + Debug> Writer<W> {
     }
 }
 
-impl<W: 'static + Write + Seek + Debug> Writer<W> {
+impl<W: 'static + Write + Seek + Debug> Writer for StdWriter<W> {
+    /// Returns the header.
+    fn header(&self) -> &Header {
+        &self.point_writer.header()
+    }
+
+    /// Writes a point.
+    fn write(&mut self, point: Point) -> Result<()> {
+        if self.closed {
+            return Err(Error::Closed.into());
+        }
+        if !point.matches(self.header().point_format()) {
+            return Err(Error::PointAttributes(*self.header().point_format(), point).into());
+        }
+        self.point_writer.write_next(point)
+    }
+}
+
+impl<W: 'static + Write + Seek + Debug> StdWriter<W> {
     /// Closes this writer and returns its inner `Write`, seeked to the beginning of the las data.
     ///
     /// # Examples
     ///
     /// ```
-    /// use las::Writer;
-    /// let writer = Writer::default();
+    /// use las::StdWriter;
+    /// let writer = StdWriter::default();
     /// let cursor = writer.into_inner().unwrap();
     /// ```
     pub fn into_inner(mut self) -> Result<W> {
@@ -340,7 +353,7 @@ impl<W: 'static + Write + Seek + Debug> Writer<W> {
     }
 }
 
-impl Writer<BufWriter<File>> {
+impl StdWriter<BufWriter<File>> {
     /// Creates a new writer for a path.
     ///
     /// If the "laz" feature is enabled, guesses from the extension if the
@@ -349,13 +362,13 @@ impl Writer<BufWriter<File>> {
     /// # Examples
     ///
     /// ```
-    /// use las::Writer;
-    /// let writer = Writer::from_path("/dev/null", Default::default());
+    /// use las::StdWriter;
+    /// let writer = StdWriter::from_path("/dev/null", Default::default());
     /// ```
     pub fn from_path<P: AsRef<Path>>(
         path: P,
         mut header: Header,
-    ) -> Result<Writer<BufWriter<File>>> {
+    ) -> Result<StdWriter<BufWriter<File>>> {
         let compress = if cfg!(feature = "laz") {
             match path.as_ref().extension() {
                 Some(ext) => match &ext.to_str() {
@@ -377,17 +390,17 @@ impl Writer<BufWriter<File>> {
         header.point_format_mut().is_compressed = compress;
         File::create(path)
             .map_err(::Error::from)
-            .and_then(|file| Writer::new(BufWriter::new(file), header))
+            .and_then(|file| StdWriter::new(BufWriter::new(file), header))
     }
 }
 
-impl Default for Writer<Cursor<Vec<u8>>> {
-    fn default() -> Writer<Cursor<Vec<u8>>> {
-        Writer::new(Cursor::new(Vec::new()), Header::default()).unwrap()
+impl Default for StdWriter<Cursor<Vec<u8>>> {
+    fn default() -> StdWriter<Cursor<Vec<u8>>> {
+        StdWriter::new(Cursor::new(Vec::new()), Header::default()).unwrap()
     }
 }
 
-impl<W: 'static + Seek + Write + Debug> Drop for Writer<W> {
+impl<W: 'static + Seek + Write + Debug> Drop for StdWriter<W> {
     fn drop(&mut self) {
         if !self.closed {
             self.close().expect("Error when dropping the writer");
@@ -405,16 +418,16 @@ mod tests {
 
     use super::*;
 
-    fn writer(format: Format, version: Version) -> Writer<Cursor<Vec<u8>>> {
+    fn writer(format: Format, version: Version) -> StdWriter<Cursor<Vec<u8>>> {
         let mut builder = Builder::default();
         builder.point_format = format;
         builder.version = version;
-        Writer::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap()
+        StdWriter::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap()
     }
 
     #[test]
     fn already_closed() {
-        let mut writer = Writer::default();
+        let mut writer = StdWriter::default();
         writer.close().unwrap();
         assert!(writer.close().is_err());
         assert!(writer.write(Default::default()).is_err());
@@ -466,14 +479,14 @@ mod tests {
     #[test]
     fn write_not_at_start() {
         use byteorder::WriteBytesExt;
-        use Reader;
+        use {Reader, StdReader};
 
         let mut cursor = Cursor::new(Vec::new());
         cursor.write_u8(42).unwrap();
-        let mut writer = Writer::new(cursor, Default::default()).unwrap();
+        let mut writer = StdWriter::new(cursor, Default::default()).unwrap();
         let point = Point::default();
         writer.write(point.clone()).unwrap();
-        let mut reader = Reader::new(writer.into_inner().unwrap()).unwrap();
+        let mut reader = StdReader::new(writer.into_inner().unwrap()).unwrap();
         assert_eq!(point, reader.read().unwrap().unwrap());
     }
 }

--- a/tests/autzen.rs
+++ b/tests/autzen.rs
@@ -5,7 +5,7 @@ extern crate las;
 macro_rules! autzen {
     ($name:ident, $major:expr, $minor:expr) => {
         mod $name {
-            use las::{Builder, Reader, Version, Writer};
+            use las::{Builder, Read, Reader, Version, Write, Writer};
             use std::io::Cursor;
 
             #[test]

--- a/tests/autzen.rs
+++ b/tests/autzen.rs
@@ -5,16 +5,16 @@ extern crate las;
 macro_rules! autzen {
     ($name:ident, $major:expr, $minor:expr) => {
         mod $name {
-            use las::{Builder, Reader, StdReader, Version, StdWriter, Writer};
+            use las::{Builder, Reader, Version, Writer};
             use std::io::Cursor;
 
             #[test]
             fn read_write() {
-                let mut reader = StdReader::from_path("tests/data/autzen.las").unwrap();
+                let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
                 let mut builder = Builder::from(reader.header().clone());
                 builder.version = Version::new($major, $minor);
                 let mut writer =
-                    StdWriter::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
+                    Writer::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
                 for point in reader.points() {
                     writer.write(point.unwrap()).unwrap();
                 }

--- a/tests/autzen.rs
+++ b/tests/autzen.rs
@@ -5,16 +5,16 @@ extern crate las;
 macro_rules! autzen {
     ($name:ident, $major:expr, $minor:expr) => {
         mod $name {
-            use las::{Builder, Reader, Version, Writer};
+            use las::{Builder, Reader, StdReader, Version, StdWriter, Writer};
             use std::io::Cursor;
 
             #[test]
             fn read_write() {
-                let mut reader = Reader::from_path("tests/data/autzen.las").unwrap();
+                let mut reader = StdReader::from_path("tests/data/autzen.las").unwrap();
                 let mut builder = Builder::from(reader.header().clone());
                 builder.version = Version::new($major, $minor);
                 let mut writer =
-                    Writer::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
+                    StdWriter::new(Cursor::new(Vec::new()), builder.into_header().unwrap()).unwrap();
                 for point in reader.points() {
                     writer.write(point.unwrap()).unwrap();
                 }

--- a/tests/laszip.rs
+++ b/tests/laszip.rs
@@ -1,13 +1,13 @@
 extern crate las;
 
-use las::Reader;
+use las::StdReader;
 
 #[test]
 fn detect_laszip() {
     if cfg!(feature = "laz") {
-        assert!(Reader::from_path("tests/data/autzen.laz").is_ok());
+        assert!(StdReader::from_path("tests/data/autzen.laz").is_ok());
     } else {
-        assert!(Reader::from_path("tests/data/autzen.laz").is_err());
+        assert!(StdReader::from_path("tests/data/autzen.laz").is_err());
     }
 }
 
@@ -18,7 +18,7 @@ mod laz_compression_test {
     /// Read file, write it compressed, read the compressed data written
     /// compare that points are the same
     fn test_compression_does_not_corrupt(path: &str) {
-        let mut reader = las::Reader::from_path(path).expect("Cannot open reader");
+        let mut reader = las::StdReader::from_path(path).expect("Cannot open reader");
         let points: Vec<las::Point> = reader.points().map(|r| r.unwrap()).collect();
 
         let mut header_builder = las::Builder::from(reader.header().version());
@@ -27,7 +27,7 @@ mod laz_compression_test {
 
         let header = header_builder.into_header().unwrap();
         let cursor = Cursor::new(Vec::<u8>::new());
-        let mut writer = las::Writer::new(cursor, header).unwrap();
+        let mut writer = las::StdWriter::new(cursor, header).unwrap();
 
         for point in &points {
             writer.write(point.clone()).unwrap();
@@ -35,7 +35,7 @@ mod laz_compression_test {
         writer.close().unwrap();
         let cursor = writer.into_inner().unwrap();
 
-        let mut reader = las::Reader::new(cursor).unwrap();
+        let mut reader = las::StdReader::new(cursor).unwrap();
         let points_2: Vec<las::Point> = reader.points().map(|r| r.unwrap()).collect();
 
         assert_eq!(points, points_2);

--- a/tests/laszip.rs
+++ b/tests/laszip.rs
@@ -14,7 +14,6 @@ fn detect_laszip() {
 #[cfg(feature = "laz")]
 mod laz_compression_test {
     use std::io::Cursor;
-    use las::{Reader, Writer};
 
     /// Read file, write it compressed, read the compressed data written
     /// compare that points are the same

--- a/tests/laszip.rs
+++ b/tests/laszip.rs
@@ -1,13 +1,13 @@
 extern crate las;
 
-use las::StdReader;
+use las::Reader;
 
 #[test]
 fn detect_laszip() {
     if cfg!(feature = "laz") {
-        assert!(StdReader::from_path("tests/data/autzen.laz").is_ok());
+        assert!(Reader::from_path("tests/data/autzen.laz").is_ok());
     } else {
-        assert!(StdReader::from_path("tests/data/autzen.laz").is_err());
+        assert!(Reader::from_path("tests/data/autzen.laz").is_err());
     }
 }
 
@@ -18,7 +18,7 @@ mod laz_compression_test {
     /// Read file, write it compressed, read the compressed data written
     /// compare that points are the same
     fn test_compression_does_not_corrupt(path: &str) {
-        let mut reader = las::StdReader::from_path(path).expect("Cannot open reader");
+        let mut reader = las::Reader::from_path(path).expect("Cannot open reader");
         let points: Vec<las::Point> = reader.points().map(|r| r.unwrap()).collect();
 
         let mut header_builder = las::Builder::from(reader.header().version());
@@ -27,7 +27,7 @@ mod laz_compression_test {
 
         let header = header_builder.into_header().unwrap();
         let cursor = Cursor::new(Vec::<u8>::new());
-        let mut writer = las::StdWriter::new(cursor, header).unwrap();
+        let mut writer = las::Writer::new(cursor, header).unwrap();
 
         for point in &points {
             writer.write(point.clone()).unwrap();
@@ -35,7 +35,7 @@ mod laz_compression_test {
         writer.close().unwrap();
         let cursor = writer.into_inner().unwrap();
 
-        let mut reader = las::StdReader::new(cursor).unwrap();
+        let mut reader = las::Reader::new(cursor).unwrap();
         let points_2: Vec<las::Point> = reader.points().map(|r| r.unwrap()).collect();
 
         assert_eq!(points, points_2);

--- a/tests/laszip.rs
+++ b/tests/laszip.rs
@@ -14,6 +14,7 @@ fn detect_laszip() {
 #[cfg(feature = "laz")]
 mod laz_compression_test {
     use std::io::Cursor;
+    use las::{Read, Write};
 
     /// Read file, write it compressed, read the compressed data written
     /// compare that points are the same

--- a/tests/laszip.rs
+++ b/tests/laszip.rs
@@ -14,6 +14,7 @@ fn detect_laszip() {
 #[cfg(feature = "laz")]
 mod laz_compression_test {
     use std::io::Cursor;
+    use las::{Reader, Writer};
 
     /// Read file, write it compressed, read the compressed data written
     /// compare that points are the same

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -4,7 +4,7 @@ extern crate chrono;
 extern crate las;
 extern crate uuid;
 
-use las::{Builder, Point, Reader, Writer};
+use las::{Builder, Point, StdReader, Reader, StdWriter, Writer};
 use std::io::Cursor;
 
 pub fn roundtrip(builder: Builder, point: &Point, should_succeed: bool) {
@@ -14,10 +14,10 @@ pub fn roundtrip(builder: Builder, point: &Point, should_succeed: bool) {
         assert!(builder.into_header().is_err());
         return;
     };
-    let mut writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
+    let mut writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
     writer.write(point.clone()).unwrap();
     let header = writer.header().clone();
-    let mut reader = Reader::new(writer.into_inner().unwrap()).unwrap();
+    let mut reader = StdReader::new(writer.into_inner().unwrap()).unwrap();
     assert_eq!(*point, reader.read().unwrap().unwrap());
     assert_eq!(reader.read().is_none(), true);
     assert_eq!(header, *reader.header());

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -4,7 +4,7 @@ extern crate chrono;
 extern crate las;
 extern crate uuid;
 
-use las::{Builder, Point, StdReader, Reader, StdWriter, Writer};
+use las::{Builder, Point, Reader, Writer};
 use std::io::Cursor;
 
 pub fn roundtrip(builder: Builder, point: &Point, should_succeed: bool) {
@@ -14,10 +14,10 @@ pub fn roundtrip(builder: Builder, point: &Point, should_succeed: bool) {
         assert!(builder.into_header().is_err());
         return;
     };
-    let mut writer = StdWriter::new(Cursor::new(Vec::new()), header).unwrap();
+    let mut writer = Writer::new(Cursor::new(Vec::new()), header).unwrap();
     writer.write(point.clone()).unwrap();
     let header = writer.header().clone();
-    let mut reader = StdReader::new(writer.into_inner().unwrap()).unwrap();
+    let mut reader = Reader::new(writer.into_inner().unwrap()).unwrap();
     assert_eq!(*point, reader.read().unwrap().unwrap());
     assert_eq!(reader.read().is_none(), true);
     assert_eq!(header, *reader.header());

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -4,7 +4,7 @@ extern crate chrono;
 extern crate las;
 extern crate uuid;
 
-use las::{Builder, Point, Reader, Writer};
+use las::{Builder, Point, Read, Reader, Write, Writer};
 use std::io::Cursor;
 
 pub fn roundtrip(builder: Builder, point: &Point, should_succeed: bool) {


### PR DESCRIPTION
Fixes #19 

Chose the Std prefix to indicate that those implementations leverage the std library (`std::io::Write`, `Seek`, etc.). Maintained the separation between Reader and Writer, so there is no single `LasFile` class.

The `Writer` trait does not include `close()`. A `flush()` may be appropriate, but `close()` has more finality and may not represent all cases (for example, you may want to flush for now, but keep the writer open in case more points come in).
