### PR TITLE
Upgrade to laz-rs v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num = "0.1"
 quick-error = "1.2"
 uuid = "0.6"
 
-laz = { version = "0.1.0", optional = true }
+laz = { version = "0.3.0", optional = true }
 
 
 [badges]


### PR DESCRIPTION
Upgraded to [`laz-rs`](https://github.com/tmontaigu/laz-rs) v0.3.0. This should fix [crashes while reading LAZ files with colors](https://github.com/tmontaigu/laz-rs/issues/13). 

Had to add lifetime specifiers to `CompressedPointReader` and `CompressedPointWriter` as they are required by `LasZipCompressor` and `LasZipDecompressor` now. 