### PR TITLE
Fix wrong point source id being returned when the data is compressed

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -512,7 +512,7 @@ impl Header {
             header_size: self.header_size()?,
             offset_to_point_data: self.offset_to_point_data()?,
             number_of_variable_length_records: self.number_of_variable_length_records()?,
-            point_data_record_format: self.point_format.to_u8()?,
+            point_data_record_format: self.point_format.to_writable_u8()?,
             point_data_record_length: self.point_format.len(),
             number_of_point_records: self.number_of_points_raw()?,
             number_of_points_by_return: self.number_of_points_by_return_raw()?,

--- a/src/point/format.rs
+++ b/src/point/format.rs
@@ -214,13 +214,21 @@ impl Format {
             if self.has_color {
                 n += 2;
             }
-
-            if self.is_compressed {
-                Ok(point_format_id_uncompressed_to_compressed(n))
-            } else {
-                Ok(n)
-            }
+            Ok(n)
         }
+    }
+
+    /// When the data is compressed (LAZ) the point format id written in the
+    /// header is slightly different to let readers know the data is compressed
+    pub(crate) fn to_writable_u8(&self) -> Result<u8> {
+        self.to_u8()
+            .map(|id|
+                if self.is_compressed {
+                    point_format_id_uncompressed_to_compressed(id)
+                } else {
+                    id
+                }
+            )
     }
 }
 

--- a/tests/laszip.rs
+++ b/tests/laszip.rs
@@ -43,6 +43,15 @@ mod laz_compression_test {
     }
 
     #[test]
+    fn test_point_format_id_is_correct() {
+        let mut las_reader = las::Reader::from_path("tests/data/autzen.las").unwrap();
+        let mut laz_reader = las::Reader::from_path("tests/data/autzen.laz").unwrap();
+
+        assert_eq!(laz_reader.header().point_format().to_u8().unwrap(), 3);
+        assert_eq!(laz_reader.header().point_format().to_u8().unwrap(), 3);
+    }
+
+    #[test]
     fn test_autzen_las() {
         test_compression_does_not_corrupt("tests/data/autzen.las");
     }


### PR DESCRIPTION
Should fix #27 