### PR TITLE
Relaxes VLR text field parsing

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -220,7 +220,7 @@ impl Reader {
         }
 
         for _ in 0..number_of_variable_length_records {
-            let vlr = raw::Vlr::read_from(&mut read, false).and_then(Vlr::new)?;
+            let vlr = raw::Vlr::read_from(&mut read, false).map(Vlr::new)?;
             position += vlr.len(false) as u64;
             builder.vlrs.push(vlr);
         }
@@ -244,7 +244,7 @@ impl Reader {
             }
             builder
                 .evlrs
-                .push(raw::Vlr::read_from(&mut read, true).and_then(Vlr::new)?);
+                .push(raw::Vlr::read_from(&mut read, true).map(Vlr::new)?);
         }
 
         read.seek(SeekFrom::Start(offset_to_point_data))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@ use {Error, Result};
 
 pub trait AsLasStr {
     fn as_las_str(&self) -> Result<&str>;
+    fn as_las_string_lossy(&self) -> String;
 }
 
 pub trait FromLasStr {
@@ -33,6 +34,13 @@ impl<'a> AsLasStr for &'a [u8] {
             Err(Error::NotAscii(s.to_string()))
         } else {
             Ok(s)
+        }
+    }
+
+    fn as_las_string_lossy(&self) -> String {
+        match self.as_las_str() {
+            Ok(s) => s.to_string(),
+            Err(_) => String::from_utf8_lossy(self).to_string(),
         }
     }
 }


### PR DESCRIPTION
Though arguably non-ASCII text fields in the VLR header
(`user_id` and `description`) are not within spec, we shouldn't barf
if we come across them. This commit relaxes to allow non-ASCII
text fields via a new `as_las_string_lossy` method. This method
first tries to convert using the more restrictive `as_las_str` method,
falling back on `String::from_utf8_lossy` if it's not valid text.

Closes #24.