### PR TITLE
update laz to version 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 num = "0.3"
 thiserror = "1.0"
 uuid = "0.8"
-laz = { version = "0.5.0", optional = true }
+laz = { version = "0.5.1", optional = true }
 
 [features]
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 num = "0.3"
 thiserror = "1.0"
 uuid = "0.8"
-laz = { version = "0.3.0", optional = true }
+laz = { version = "0.5.0", optional = true }
 
 [features]
 unstable = []

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -75,7 +75,7 @@ pub(crate) fn read_point_from<R: std::io::Read>(
 }
 
 /// Trait to specify behaviour a a PointReader
-pub(crate) trait PointReader: Debug {
+pub(crate) trait PointReader: Debug + Send {
     fn read_next(&mut self) -> Option<Result<Point>>;
     fn seek(&mut self, position: u64) -> Result<()>;
     fn header(&self) -> &Header;
@@ -106,7 +106,7 @@ struct UncompressedPointReader<R: std::io::Read + Seek> {
     last_point_idx: u64,
 }
 
-impl<R: std::io::Read + Seek + Debug> PointReader for UncompressedPointReader<R> {
+impl<R: std::io::Read + Seek + Debug + Send> PointReader for UncompressedPointReader<R> {
     fn read_next(&mut self) -> Option<Result<Point>> {
         if self.last_point_idx < self.header.number_of_points() {
             self.last_point_idx += 1;
@@ -203,7 +203,7 @@ impl Reader {
     /// let file = File::open("tests/data/autzen.las").unwrap();
     /// let reader = Reader::new(BufReader::new(file)).unwrap();
     /// ```
-    pub fn new<R: std::io::Read + Seek + Debug + 'static>(mut read: R) -> Result<Reader> {
+    pub fn new<R: std::io::Read + Seek + Send + Debug + 'static>(mut read: R) -> Result<Reader> {
         use std::io::Read;
 
         let raw_header = raw::Header::read_from(&mut read)?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -207,7 +207,7 @@ pub trait Write {
 pub struct Writer<W: 'static + std::io::Write + Seek + Debug + Send> {
     closed: bool,
     start: u64,
-    point_writer: Box<dyn PointWriter<W>>,
+    point_writer: Box<dyn PointWriter<W> + Send>,
 }
 
 impl<W: 'static + std::io::Write + Seek + Debug + Send> Writer<W> {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -72,7 +72,7 @@ pub(crate) fn write_point_to<W: std::io::Write>(
 }
 
 /// Trait that defines a PointWriter, s
-pub(crate) trait PointWriter<W: std::io::Write>: Debug {
+pub(crate) trait PointWriter<W: std::io::Write>: Debug + Send {
     fn write_next(&mut self, point: Point) -> Result<()>;
     //https://users.rust-lang.org/t/is-there-a-way-to-move-a-trait-object/707
     fn into_inner(self: Box<Self>) -> W;
@@ -115,7 +115,7 @@ struct UncompressedPointWriter<W: std::io::Write + Debug> {
     header: Header,
 }
 
-impl<W: std::io::Write + Debug> PointWriter<W> for UncompressedPointWriter<W> {
+impl<W: std::io::Write + Debug + Send> PointWriter<W> for UncompressedPointWriter<W> {
     fn write_next(&mut self, point: Point) -> Result<()> {
         self.header.add_point(&point);
         write_point_to(&mut self.dest, point, &self.header)?;
@@ -204,13 +204,13 @@ pub trait Write {
 /// } // <- `close` is not called
 /// ```
 #[derive(Debug)]
-pub struct Writer<W: 'static + std::io::Write + Seek + Debug> {
+pub struct Writer<W: 'static + std::io::Write + Seek + Debug + Send> {
     closed: bool,
     start: u64,
     point_writer: Box<dyn PointWriter<W>>,
 }
 
-impl<W: 'static + std::io::Write + Seek + Debug> Writer<W> {
+impl<W: 'static + std::io::Write + Seek + Debug + Send> Writer<W> {
     /// Creates a new writer.
     ///
     /// The header that is passed in will have various fields zero'd, e.g. bounds, number of
@@ -303,7 +303,7 @@ impl<W: 'static + std::io::Write + Seek + Debug> Writer<W> {
     }
 }
 
-impl<W: 'static + std::io::Write + Seek + Debug> Write for Writer<W> {
+impl<W: 'static + std::io::Write + Seek + Debug + Send> Write for Writer<W> {
     /// Returns a reference to this writer's header.
     fn header(&self) -> &Header {
         &self.point_writer.header()
@@ -325,7 +325,7 @@ impl<W: 'static + std::io::Write + Seek + Debug> Write for Writer<W> {
     }
 }
 
-impl<W: 'static + std::io::Write + Seek + Debug> Writer<W> {
+impl<W: 'static + std::io::Write + Seek + Debug + Send> Writer<W> {
     /// Closes this writer and returns its inner `Write`, seeked to the beginning of the las data.
     ///
     /// # Examples
@@ -402,7 +402,7 @@ impl Default for Writer<Cursor<Vec<u8>>> {
     }
 }
 
-impl<W: 'static + Seek + std::io::Write + Debug> Drop for Writer<W> {
+impl<W: 'static + Seek + std::io::Write + Debug + Send> Drop for Writer<W> {
     fn drop(&mut self) {
         if !self.closed {
             self.close().expect("Error when dropping the writer");


### PR DESCRIPTION
Enable point format >= 6 compression using laz

Make the reader & writer Send because laz::LasZipCompressor & laz::LasZipDecompressor need it. This require the `R` and `W` parameter type of the `Reader` and  `Writer` to be `Send` too, this should not be a problem since `std::fs::File` and `std::io::Cursor<T>` are Send and they probably are used in 99% of the cases


(should also close #33 )