### PR TITLE
Fix for arbitrary EVLR offset.

### DIFF
--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -494,6 +494,36 @@ mod tests {
         assert!(write_read(header).is_err());
     }
 
+    #[test]
+    fn number_of_evlrs_none() {
+        let mut buff = Cursor::new(vec![
+            0;
+            std::mem::size_of::<u64>() + std::mem::size_of::<u32>()
+        ]);
+
+        buff.write(&u64::MAX.to_le_bytes()).unwrap();
+        buff.write(&0_u32.to_le_bytes()).unwrap();
+
+        buff.set_position(0);
+        let evlr = Evlr::read_from(buff).unwrap();
+        assert!(evlr.into_option().is_none());
+    }
+
+    #[test]
+    fn number_of_evlrs_some() {
+        let mut buff = Cursor::new(vec![
+            0;
+            std::mem::size_of::<u64>() + std::mem::size_of::<u32>()
+        ]);
+
+        buff.write(&u64::MAX.to_le_bytes()).unwrap();
+        buff.write(&1_u32.to_le_bytes()).unwrap();
+
+        buff.set_position(0);
+        let evlr = Evlr::read_from(buff).unwrap();
+        assert!(evlr.into_option().is_some());
+    }
+
     macro_rules! roundtrip {
         ($name:ident, $minor:expr) => {
             mod $name {

--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -450,10 +450,10 @@ impl Evlr {
     }
 
     fn into_option(self) -> Option<Evlr> {
-        if self.start_of_first_evlr == 0 && self.number_of_evlrs == 0 {
-            None
-        } else {
+        if self.start_of_first_evlr > 0 && self.number_of_evlrs > 0 {
             Some(self)
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
This changes the optional EVLR struct to only be added to the header if both the EVLR offset and number of EVLRs in the public header indicates a nonzero number of entries.

This addresses an issue where LASfiles output from PDAL were not being read by `las-rs` because while the number of EVLRs was set to 0, the offset was set as being the total length of the file. (see https://github.com/PDAL/PDAL/issues/3350)

The LAS spec is frustratingly vague on what values should be set in this case.
http://www.asprs.org/wp-content/uploads/2019/07/LAS_1_4_r15.pdf#subsection.0.2.4

I think this change will safely allow the header to be parsed regardless of the value of the offset when the EVLR count is specifically 0.

Also, I intend to update this PR with a test case on Monday morning.