### PR TITLE
Replace num crate with num-traits crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["science", "data-structures"]
 byteorder = "1.4"
 chrono = "0.4"
 log = "0.4"
-num = "0.4"
+num-traits = "0.2"
 thiserror = "1.0"
 uuid = "0.8"
 laz = { version = "0.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@
 
 extern crate byteorder;
 extern crate chrono;
-extern crate num;
+extern crate num_traits;
 extern crate thiserror;
 extern crate uuid;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use num::Zero;
+use num_traits::Zero;
 use std::str;
 use {Error, Result};
 


### PR DESCRIPTION
The `num` crate pulls in a lot of dependencies, but only one feature of the `num-traits` crate was actually being used. This PR replaces the dependency on `num` with a dependency on `num-traits`.