### PR TITLE
Fix EVLR decoding for laz files

### DIFF
--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -317,18 +317,6 @@ impl Header {
         Ok(header)
     }
 
-    /// Returns the total file offset to the first byte *after* all of the points.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use las::raw::Header;
-    /// assert_eq!(227, Header::default().offset_to_end_of_points());
-    /// ```
-    pub fn offset_to_end_of_points(&self) -> u64 {
-        u64::from(self.offset_to_point_data)
-            + u64::from(self.number_of_point_records) * u64::from(self.point_data_record_length)
-    }
 
     /// Writes a raw header to a `Write`.
     ///

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -210,7 +210,6 @@ impl<'a> Reader<'a> {
         let mut position = u64::from(raw_header.header_size);
         let number_of_variable_length_records = raw_header.number_of_variable_length_records;
         let offset_to_point_data = u64::from(raw_header.offset_to_point_data);
-        let offset_to_end_of_points = raw_header.offset_to_end_of_points();
         let evlr = raw_header.evlr;
 
         let mut builder = Builder::new(raw_header)?;
@@ -236,20 +235,8 @@ impl<'a> Reader<'a> {
             }
         }
 
-        read.seek(SeekFrom::Start(offset_to_end_of_points))?;
         if let Some(evlr) = evlr {
-            match evlr.start_of_first_evlr.cmp(&offset_to_end_of_points) {
-                Ordering::Less => {
-                    return Err(Error::OffsetToEvlrsTooSmall(evlr.start_of_first_evlr).into())
-                }
-                Ordering::Equal => {} // pass
-                Ordering::Greater => {
-                    let n = evlr.start_of_first_evlr - offset_to_end_of_points;
-                    read.by_ref()
-                        .take(n)
-                        .read_to_end(&mut builder.point_padding)?;
-                }
-            }
+            read.seek(SeekFrom::Start(evlr.start_of_first_evlr))?;
             builder
                 .evlrs
                 .push(raw::Vlr::read_from(&mut read, true).map(Vlr::new)?);


### PR DESCRIPTION
`offset_to_end_of_points()` is wrong for compressed files because it deals with the uncompressed size. This change fixes EVLR decoding to handle laz files.
