### PR TITLE
Bump laz-rs to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 num-traits = "0.2"
 thiserror = "1.0"
 uuid = "1"
-laz = { version = "0.6", optional = true }
+laz = { version = "0.7", optional = true }
 
 [features]
 unstable = []


### PR DESCRIPTION
[laz-rs 0.7.0] just released with some improvements, and the `--all-features` tests still succeed!

[laz-rs 0.7.0]: https://github.com/laz-rs/laz-rs/commit/77a19fb8e7443caab71e982f32de1bd09370102c
