### PR TITLE
Quick and dirty hack to support AsyncReader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ log = "0.4"
 num-traits = "0.2"
 thiserror = "1.0"
 uuid = "1"
+# laz = { version = "0.7" }
 laz = { version = "0.7", optional = true }
+futures = "0.3.26"
+byteorder_async = { version = "1.1.0", features = ["futures_async"], path = "../byteorder_async" }
+async-trait = "0.1.64"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -1,12 +1,12 @@
 use crate::error::Error;
-use laz::las::laszip::LazVlr;
 use crate::reader::{read_point_from, PointReader};
+use crate::writer::{write_header_and_vlrs_to, write_point_to, PointWriter};
+use crate::{Header, Point, Result, Vlr};
+use laz::las::laszip::LazVlr;
 use std::fmt::Debug;
 /// Module with functions and structs specific to brigde the las crate and laz crate to allow
 /// writing & reading LAZ data
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
-use crate::writer::{write_header_and_vlrs_to, write_point_to, PointWriter};
-use crate::{Header, Point, Result, Vlr};
 
 fn is_laszip_vlr(vlr: &Vlr) -> bool {
     vlr.user_id == LazVlr::USER_ID && vlr.record_id == LazVlr::RECORD_ID

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
+use crate::{header, point, reader, vlr, writer, Transform, Version};
 use std::io;
 use std::str;
 use thiserror::Error;
-use crate::{header, point, reader, vlr, writer, Transform, Version};
 
 /// Crate-specific error enum.
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,7 @@ extern crate laz;
 #[cfg(feature = "laz")]
 mod compression;
 
+pub mod async_reader;
 pub mod feature;
 pub mod header;
 pub mod point;
@@ -177,6 +178,7 @@ mod utils;
 mod vector;
 mod version;
 
+pub use crate::async_reader::{AsyncRead, AsyncReader};
 pub use crate::bounds::Bounds;
 pub use crate::color::Color;
 pub use crate::error::Error;

--- a/src/point/format.rs
+++ b/src/point/format.rs
@@ -172,7 +172,7 @@ impl Format {
     /// assert_eq!(6, format.to_u8().unwrap());
     /// ```
     pub fn to_u8(&self) -> Result<u8> {
-        if !cfg!(feature = "laz") && self.is_compressed {
+        if false && !cfg!(feature = "laz") && self.is_compressed {
             Err(Error::Format(*self).into())
         } else if self.is_extended {
             if self.has_gps_time {

--- a/src/raw/async_header.rs
+++ b/src/raw/async_header.rs
@@ -1,0 +1,182 @@
+//! Raw file metadata.
+
+use crate::feature::{Evlrs, LargeFiles, Waveforms};
+use crate::raw::LASF;
+use crate::raw::{header::Evlr, header::LargeFile, Header};
+use crate::{reader, Result, Version};
+// use byteorder::{ByteOrder, LittleEndian};
+use byteorder_async::{LittleEndian, ReaderToByteOrder};
+use futures::future::{AndThen, MapOk};
+use futures::io::{AsyncRead, AsyncReadExt, ReadExact};
+use futures::task::{Context, Poll};
+use futures::{Future, TryFuture, TryFutureExt};
+use std::future::IntoFuture;
+use std::marker::{PhantomData, Unpin};
+use std::pin::Pin;
+
+impl Header {
+    /// Reads a raw header from a `AsyncRead`.
+    ///
+    /// Generally very permissive, but will throw an error if a couple of things are true:
+    ///
+    /// - The file signature is not exactly "LASF".
+    /// - The point data format is not recognized. Note that version mismatches *are* allowed (e.g.
+    /// color points for las 1.1).
+    /// - The point data record length is less than the minimum length of the point data format.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs::File;
+    /// use las::raw::Header;
+    /// let mut file = File::open("tests/data/autzen.las").unwrap();
+    /// let header = Header::read_from(&mut file).unwrap();
+    /// ```
+    pub async fn read_from_async<R: AsyncRead + Unpin>(mut the_read: R) -> Result<Header> {
+        use crate::header::Error;
+        use crate::utils;
+
+        let mut read = the_read.byte_order();
+
+        let mut header = Header::default();
+
+        read.read_exact(&mut header.file_signature).await?;
+        if header.file_signature != LASF {
+            return Err(Error::FileSignature(header.file_signature).into());
+        }
+        header.file_source_id = read.read_u16::<LittleEndian>().await?;
+        header.global_encoding = read.read_u16::<LittleEndian>().await?;
+        read.read_exact(&mut header.guid).await?;
+        let version_major = read.read_u8().await?;
+        let version_minor = read.read_u8().await?;
+        header.version = Version::new(version_major, version_minor);
+        read.read_exact(&mut header.system_identifier).await?;
+        read.read_exact(&mut header.generating_software).await?;
+        header.file_creation_day_of_year = read.read_u16::<LittleEndian>().await?;
+        header.file_creation_year = read.read_u16::<LittleEndian>().await?;
+        header.header_size = read.read_u16::<LittleEndian>().await?;
+        header.offset_to_point_data = read.read_u32::<LittleEndian>().await?;
+        header.number_of_variable_length_records = read.read_u32::<LittleEndian>().await?;
+        header.point_data_record_format = read.read_u8().await?;
+        header.point_data_record_length = read.read_u16::<LittleEndian>().await?;
+        header.number_of_point_records = read.read_u32::<LittleEndian>().await?;
+        for n in &mut header.number_of_points_by_return {
+            *n = read.read_u32::<LittleEndian>().await?;
+        }
+        header.x_scale_factor = read.read_f64::<LittleEndian>().await?;
+        header.y_scale_factor = read.read_f64::<LittleEndian>().await?;
+        header.z_scale_factor = read.read_f64::<LittleEndian>().await?;
+        header.x_offset = read.read_f64::<LittleEndian>().await?;
+        header.y_offset = read.read_f64::<LittleEndian>().await?;
+        header.z_offset = read.read_f64::<LittleEndian>().await?;
+        header.max_x = read.read_f64::<LittleEndian>().await?;
+        header.min_x = read.read_f64::<LittleEndian>().await?;
+        header.max_y = read.read_f64::<LittleEndian>().await?;
+        header.min_y = read.read_f64::<LittleEndian>().await?;
+        header.max_z = read.read_f64::<LittleEndian>().await?;
+        header.min_z = read.read_f64::<LittleEndian>().await?;
+        header.start_of_waveform_data_packet_record = if header.version.supports::<Waveforms>() {
+            utils::some_or_none_if_zero(read.read_u64::<LittleEndian>().await?)
+        } else {
+            None
+        };
+        header.evlr = if header.version.supports::<Evlrs>() {
+            // I'm too tired to fight with this
+            // Copy paste for the rescue
+            Evlr {
+                start_of_first_evlr: read.read_u64::<LittleEndian>().await?,
+                number_of_evlrs: read.read_u32::<LittleEndian>().await?,
+            }
+            .into_option()
+        } else {
+            None
+        };
+        header.large_file = if header.version.supports::<LargeFiles>() {
+            let number_of_point_records = read.read_u64::<LittleEndian>().await?;
+            let mut number_of_points_by_return = [0; 15];
+            for n in &mut number_of_points_by_return {
+                *n = read.read_u64::<LittleEndian>().await?
+            }
+            Some(LargeFile {
+                number_of_point_records,
+                number_of_points_by_return,
+            })
+        } else {
+            None
+        };
+        header.padding = if header.header_size > header.version.header_size() {
+            let mut bytes = vec![0; (header.header_size - header.version.header_size()) as usize];
+            read.read_exact(&mut bytes).await?;
+            bytes
+        } else {
+            Vec::new()
+        };
+        Ok(header)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    async fn write_read(header: Header) -> Result<()> {
+        let mut cursor = Cursor::new(Vec::new());
+        header.write_to(&mut cursor).unwrap();
+        cursor.set_position(0);
+
+        let async_cursor = futures::io::Cursor::new(cursor.into_inner());
+        Header::read_from_async(async_cursor).await?;
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_file_signature() {
+        let header = Header {
+            file_signature: *b"ABCD",
+            ..Default::default()
+        };
+
+        assert!(futures::executor::block_on(async {
+            write_read(header).await.is_err()
+        }));
+    }
+
+    macro_rules! roundtrip {
+        ($name:ident, $minor:expr) => {
+            mod $name {
+                #[test]
+                fn roundtrip() {
+                    use super::*;
+                    use std::io::Cursor;
+
+                    let version = Version::new(1, $minor);
+                    let mut header = Header {
+                        version,
+                        ..Default::default()
+                    };
+                    if version.minor == 4 {
+                        header.large_file = Some(LargeFile::default());
+                    }
+                    let mut cursor = Cursor::new(Vec::new());
+                    header.write_to(&mut cursor).unwrap();
+                    cursor.set_position(0);
+
+                    let async_cursor = futures::io::Cursor::new(cursor.into_inner());
+                    assert_eq!(
+                        header,
+                        futures::executor::block_on(async {
+                            Header::read_from_async(async_cursor).await.unwrap()
+                        })
+                    );
+                }
+            }
+        };
+    }
+
+    roundtrip!(las_1_0, 0);
+    roundtrip!(las_1_1, 1);
+    roundtrip!(las_1_2, 2);
+    roundtrip!(las_1_3, 3);
+    roundtrip!(las_1_4, 4);
+}

--- a/src/raw/async_point.rs
+++ b/src/raw/async_point.rs
@@ -1,0 +1,89 @@
+//! Point::read_from_async
+use crate::point::Format;
+use crate::raw::point::{Flags, ScanAngle, Waveform};
+use crate::raw::Point;
+use crate::Color;
+use crate::Result;
+use byteorder_async::ReaderToByteOrder;
+use futures::io::AsyncRead;
+
+impl Point {
+    /// Reads a raw point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::{Seek, SeekFrom};
+    /// use std::fs::File;
+    /// use las::raw::Point;
+    /// use las::point::Format;
+    /// let mut file = File::open("tests/data/autzen.las").unwrap();
+    /// file.seek(SeekFrom::Start(1994)).unwrap();
+    /// let point = Point::read_from(file, &Format::new(1).unwrap()).unwrap();
+    /// ```
+    #[allow(clippy::field_reassign_with_default)]
+    pub async fn read_from_async<R: AsyncRead + Unpin>(
+        mut read: R,
+        format: &Format,
+    ) -> Result<Point> {
+        use crate::utils;
+        use byteorder_async::LittleEndian;
+
+        let mut read = read.byte_order();
+
+        let mut point = Point::default();
+        point.x = read.read_i32::<LittleEndian>().await?;
+        point.y = read.read_i32::<LittleEndian>().await?;
+        point.z = read.read_i32::<LittleEndian>().await?;
+        point.intensity = read.read_u16::<LittleEndian>().await?;
+        point.flags = if format.is_extended {
+            Flags::ThreeByte(
+                read.read_u8().await?,
+                read.read_u8().await?,
+                read.read_u8().await?,
+            )
+        } else {
+            Flags::TwoByte(read.read_u8().await?, read.read_u8().await?)
+        };
+        if format.is_extended {
+            point.user_data = read.read_u8().await?;
+            point.scan_angle = ScanAngle::Scaled(read.read_i16::<LittleEndian>().await?);
+        } else {
+            point.scan_angle = ScanAngle::Rank(read.read_i8().await?);
+            point.user_data = read.read_u8().await?;
+        };
+        point.point_source_id = read.read_u16::<LittleEndian>().await?;
+        point.gps_time = if format.has_gps_time {
+            utils::some_or_none_if_zero(read.read_f64::<LittleEndian>().await?)
+        } else {
+            None
+        };
+        point.color = if format.has_color {
+            let red = read.read_u16::<LittleEndian>().await?;
+            let green = read.read_u16::<LittleEndian>().await?;
+            let blue = read.read_u16::<LittleEndian>().await?;
+            Some(Color::new(red, green, blue))
+        } else {
+            None
+        };
+        point.waveform = if format.has_waveform {
+            Some(Waveform::read_from_async(read.get_mut()).await?)
+        } else {
+            None
+        };
+        point.nir = if format.has_nir {
+            utils::some_or_none_if_zero(read.read_u16::<LittleEndian>().await?)
+        } else {
+            None
+        };
+        point.extra_bytes.resize(format.extra_bytes as usize, 0);
+        read.read_exact(&mut point.extra_bytes).await?;
+        Ok(point)
+    }
+}
+
+impl Waveform {
+    async fn read_from_async<R: AsyncRead + Unpin>(mut read: R) -> Result<Waveform> {
+        todo!()
+    }
+}

--- a/src/raw/async_vlr.rs
+++ b/src/raw/async_vlr.rs
@@ -1,0 +1,43 @@
+//! Implementation for Vlr::read_from_async
+use crate::raw::vlr::RecordLength;
+use crate::raw::Vlr;
+use crate::Result;
+use byteorder_async::ReaderToByteOrder;
+use futures::io::AsyncRead;
+
+impl Vlr {
+    /// Reads a raw VLR or EVLR.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::{Seek, SeekFrom};
+    /// use std::fs::File;
+    /// use las::raw::Vlr;
+    /// let mut file = File::open("tests/data/autzen.las").unwrap();
+    /// file.seek(SeekFrom::Start(227));
+    /// // If the second parameter were true, it would be read as an extended vlr.
+    /// let vlr = Vlr::read_from(file, false).unwrap();
+    /// ```
+    #[allow(clippy::field_reassign_with_default)]
+    pub async fn read_from_async<R: AsyncRead + Unpin>(mut read: R, extended: bool) -> Result<Vlr> {
+        use byteorder_async::LittleEndian;
+
+        let mut read = read.byte_order();
+
+        let mut vlr = Vlr::default();
+        vlr.reserved = read.read_u16::<LittleEndian>().await?;
+        read.read_exact(&mut vlr.user_id).await?;
+        vlr.record_id = read.read_u16::<LittleEndian>().await?;
+        vlr.record_length_after_header = if extended {
+            RecordLength::Evlr(read.read_u64::<LittleEndian>().await?)
+        } else {
+            RecordLength::Vlr(read.read_u16::<LittleEndian>().await?)
+        };
+        read.read_exact(&mut vlr.description).await?;
+        vlr.data
+            .resize(usize::from(vlr.record_length_after_header), 0);
+        read.read_exact(&mut vlr.data).await?;
+        Ok(vlr)
+    }
+}

--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -1,10 +1,10 @@
 //! Raw file metadata.
 
-use byteorder::{LittleEndian, ReadBytesExt};
 use crate::feature::{Evlrs, LargeFiles, Waveforms};
 use crate::raw::LASF;
-use std::io::{Read, Write};
 use crate::{Result, Version};
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::{Read, Write};
 
 /// A las header.
 ///
@@ -449,7 +449,7 @@ impl Evlr {
         })
     }
 
-    fn into_option(self) -> Option<Evlr> {
+    pub(crate) fn into_option(self) -> Option<Evlr> {
         if self.start_of_first_evlr > 0 && self.number_of_evlrs > 0 {
             Some(self)
         } else {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -35,6 +35,9 @@
 //! Vlr::read_from(&mut cursor, false).unwrap();
 //! ```
 
+pub mod async_header;
+pub mod async_point;
+pub mod async_vlr;
 pub mod header;
 pub mod point;
 pub mod vlr;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -206,7 +206,9 @@ impl<'a> Reader<'a> {
     pub fn new<R: std::io::Read + Seek + Send + Debug + 'a>(mut read: R) -> Result<Reader<'a>> {
         use std::io::Read;
 
-        let raw_header = raw::Header::read_from(&mut read)?;
+        let mut raw_header = raw::Header::read_from(&mut read)?;
+        raw_header.finish_parsing(&mut read)?;
+
         let mut position = u64::from(raw_header.header_size);
         let number_of_variable_length_records = raw_header.number_of_variable_length_records;
         let offset_to_point_data = u64::from(raw_header.offset_to_point_data);


### PR DESCRIPTION
This is not a fully fledged PR, just a discussion point.

I was going to use `las-rs` for web based LAS manipulations. Compile to WASM and extract metadata (and points in the future). But for proper support on javascript side all IO should be async.

Just checking is my approach somewhat reasonable to drive it to completion ready to merge. Or there is a better way of doing it?

(I also implemented `AsyncRead` for `Reqwest`, so I can actually do bytes range http requests to fetch parts of remote LAZ files without dowloading them in whole)