### PR TITLE
Las1.1 support is failing, forcing the header to 1.2 seems to work?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2023-08-24
+
+ - Testing of las v1.1 inputs
+
 ## [Unreleased]
 
 ## [0.8.1] - 2023-03-14

--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -272,6 +272,13 @@ impl Header {
         }
         read.read_exact(&mut header.system_identifier)?;
         read.read_exact(&mut header.generating_software)?;
+        for i in 0..header.generating_software.len() {
+            if header.generating_software[i] == b'0' {
+                for j in i+1..header.generating_software.len() {
+                    header.generating_software[j] = b'0';
+                }
+            }
+        }
         header.file_creation_day_of_year = read.read_u16::<LittleEndian>()?;
         header.file_creation_year = read.read_u16::<LittleEndian>()?;
         header.header_size = read.read_u16::<LittleEndian>()?;

--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -267,6 +267,9 @@ impl Header {
         let version_major = read.read_u8()?;
         let version_minor = read.read_u8()?;
         header.version = Version::new(version_major, version_minor);
+        if version_minor == 1 {
+            header.version = Version::new(version_major, 2);
+        }
         read.read_exact(&mut header.system_identifier)?;
         read.read_exact(&mut header.generating_software)?;
         header.file_creation_day_of_year = read.read_u16::<LittleEndian>()?;


### PR DESCRIPTION
**This should not be merged!**
It is just a proof of concept that when reading a las 1.1 file fails, forcing the version field to 1.2 does work. I have spent a couple of days trying to trace into the libraries to discover where the panic on 1.1 is happening but have not been able to do so, sorry!