### PR TITLE
Add API that allows reading many points

### DIFF
--- a/tests/autzen.rs
+++ b/tests/autzen.rs
@@ -89,3 +89,100 @@ fn test_seek_0_works_on_las() {
 fn test_seek_0_works_on_laz() {
     test_seek_0_works_on("tests/data/autzen.laz");
 }
+
+fn test_read_n_on(path: &str) {
+    use las::{Point, Read, Reader};
+
+    let ground_truth_points = {
+        let mut ground_truth_reader = Reader::from_path(path).unwrap();
+        ground_truth_reader
+            .points()
+            .collect::<las::Result<Vec<Point>>>()
+            .unwrap()
+    };
+
+    let mut reader = Reader::from_path(path).unwrap();
+    let n = 7;
+    let mut all_points = Vec::with_capacity(reader.header().number_of_points() as usize);
+    loop {
+        let mut points = reader.read_n(n).unwrap();
+        if points.len() == 0 {
+            break;
+        }
+        all_points.append(&mut points);
+    }
+
+    assert_eq!(all_points, ground_truth_points);
+}
+
+fn test_read_n_into_on(path: &str) {
+    use las::{Point, Read, Reader};
+
+    let ground_truth_points = {
+        let mut ground_truth_reader = Reader::from_path(path).unwrap();
+        ground_truth_reader
+            .points()
+            .collect::<las::Result<Vec<Point>>>()
+            .unwrap()
+    };
+
+    let mut reader = Reader::from_path(path).unwrap();
+    let n = 7;
+    let mut all_points = Vec::with_capacity(reader.header().number_of_points() as usize);
+    let mut points_buffer = Vec::with_capacity(n as usize);
+    while reader.read_n_into(n, &mut points_buffer).unwrap() != 0 {
+        all_points.append(&mut points_buffer);
+    }
+
+    assert_eq!(all_points, ground_truth_points);
+}
+
+#[test]
+fn test_las_read_n() {
+    test_read_n_on("tests/data/autzen.las");
+}
+
+#[cfg(feature = "laz")]
+#[test]
+fn test_laz_read_n() {
+    test_read_n_on("tests/data/autzen.laz");
+}
+
+#[test]
+fn test_las_read_n_into() {
+    test_read_n_into_on("tests/data/autzen.las");
+}
+
+#[cfg(feature = "laz")]
+#[test]
+fn test_laz_read_n_into() {
+    test_read_n_into_on("tests/data/autzen.laz");
+}
+
+fn test_read_all_points_on(path: &str) {
+    use las::{Point, Read, Reader};
+
+    let ground_truth_points = {
+        let mut ground_truth_reader = Reader::from_path(path).unwrap();
+        ground_truth_reader
+            .points()
+            .collect::<las::Result<Vec<Point>>>()
+            .unwrap()
+    };
+
+    let mut reader = Reader::from_path(path).unwrap();
+    let mut all_points = vec![];
+    reader.read_all_points(&mut all_points).unwrap();
+    assert_eq!(all_points, ground_truth_points);
+}
+
+#[test]
+fn test_las_read_all_points() {
+    test_read_all_points_on("tests/data/autzen.las");
+}
+
+#[cfg(feature = "laz")]
+#[test]
+fn test_laz_read_all_points() {
+    test_read_all_points_on("tests/data/autzen.laz");
+}


### PR DESCRIPTION
This adds to the API of the reader some functions
that allows to read many points in one call.

There are few variants, depending on how the user wants to be conservative with allocations.

Also ideally, there would be a
`read_into(&mut self, buf: &mut [Point]) -> Result<u64>` In order to avoid more allocations (especially the potential extra bytes), but for that there needs to exist a
`Point::read_into(raw: &RawPoint, dest_point: &mut Point)` or similar. Which could be added later.

The main point for these methods, is that it will later allow to make use of laz-rs parrallel decompressor to greatly speed-up reading LAZ files.

If needed, we could add later an iterator that returns vecs of points e.g:
```
fn chunks(points_per_chunk: u64) -> impl Iterator<Item=Vec<Point>>>
```