### PR TITLE
feat: add laz-parallel feature

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: ["", "--features laz"]
+        features: ["", "--features laz", "--features laz-parallel"]
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,14 @@ log = "0.4"
 num-traits = "0.2"
 thiserror = "1.0"
 uuid = "1"
-laz = { version = "0.9", optional = true }
+laz = { version = "0.9.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
+
+[features]
+laz = ["dep:laz"]
+laz-parallel = ["dep:laz", "laz/parallel"]
 
 [[bench]]
 name = "roundtrip"


### PR DESCRIPTION
This adds the `laz-parallel` feature
(which enables laz-rs if not already enabled).

When enabled, las-rs will use laz-rs parallel decompressor when reading many points at once (read_n_into, read_next_points) improving the read speed

For example, using the file linked in #64:
- with `features=laz` using calls to read(), read_n_into, etc I read all the points in 28s
- with `features=laz-parallel` and calls to read() I read the all the points in 28s
- with `features=laz-parallel` and calls to read_n_into(),read_all_points I read the all the points in 8s