### PR TITLE
refactor: remove duplicate functions and simplify code

### DIFF
--- a/src/laz.rs
+++ b/src/laz.rs
@@ -83,7 +83,7 @@ impl Header {
         Ok(())
     }
 
-    /// Returns header's [LazVlr], or `None` if none is found.
+    /// Returns header's [LazVlr], or `Error::LasZipVlrNotFound` if none is found.
     ///
     /// # Examples
     ///
@@ -94,16 +94,16 @@ impl Header {
     ///
     /// #[cfg(feature = "laz")]
     /// {
-    /// assert!(header.laz_vlr().is_none());
+    /// assert!(header.laz_vlr().is_err());
     /// header.add_laz_vlr();
-    /// assert!(header.laz_vlr().is_some());
+    /// assert!(header.laz_vlr().is_ok());
     /// }
     /// ```
-    pub fn laz_vlr(&self) -> Option<LazVlr> {
+    pub fn laz_vlr(&self) -> Result<LazVlr> {
         self.vlrs
             .iter()
             .find(|vlr| is_laszip_vlr(vlr))
-            .and_then(|vlr| vlr.try_into().ok())
+            .map_or(Err(Error::LasZipVlrNotFound), |vlr| vlr.try_into())
     }
 }
 

--- a/src/reader/laz.rs
+++ b/src/reader/laz.rs
@@ -1,6 +1,6 @@
 use super::ReadPoints;
-use crate::{raw, Error, Header, Point, Result, Vlr};
-use laz::{LazDecompressor, LazVlr};
+use crate::{raw, Error, Header, Point, Result};
+use laz::LazDecompressor;
 use std::io::{Cursor, Read, Seek};
 
 pub(crate) struct PointReader<D: LazDecompressor> {
@@ -16,8 +16,8 @@ impl<R: Read + Seek> PointReader<laz::ParLasZipDecompressor<R>> {
         read: R,
         header: Header,
     ) -> Result<PointReader<laz::ParLasZipDecompressor<R>>> {
-        let (vlr, buffer) = vlr_and_buffer(&header)?;
-        let decompressor = laz::ParLasZipDecompressor::new(read, vlr)?;
+        let decompressor = laz::ParLasZipDecompressor::new(read, header.laz_vlr()?)?;
+        let buffer = Cursor::new(vec![0u8; header.point_format().len().into()]);
         Ok(PointReader {
             decompressor,
             header,
@@ -33,8 +33,8 @@ impl<R: Read + Seek + Send> PointReader<laz::LasZipDecompressor<'_, R>> {
         read: R,
         header: Header,
     ) -> Result<PointReader<laz::LasZipDecompressor<'static, R>>> {
-        let (vlr, buffer) = vlr_and_buffer(&header)?;
-        let decompressor = laz::LasZipDecompressor::new(read, vlr)?;
+        let decompressor = laz::LasZipDecompressor::new(read, header.laz_vlr()?)?;
+        let buffer = Cursor::new(vec![0u8; header.point_format().len().into()]);
         Ok(PointReader {
             decompressor,
             header,
@@ -91,17 +91,4 @@ where
     fn header(&self) -> &Header {
         &self.header
     }
-}
-
-fn is_laszip_vlr(vlr: &Vlr) -> bool {
-    vlr.user_id == LazVlr::USER_ID && vlr.record_id == LazVlr::RECORD_ID
-}
-
-fn vlr_and_buffer(header: &Header) -> Result<(LazVlr, Cursor<Vec<u8>>)> {
-    let vlr = match header.vlrs().iter().find(|vlr| is_laszip_vlr(vlr)) {
-        None => return Err(Error::LasZipVlrNotFound),
-        Some(vlr) => LazVlr::from_buffer(&vlr.data)?,
-    };
-    let buffer = Cursor::new(vec![0u8; header.point_format().len().into()]);
-    Ok((vlr, buffer))
 }

--- a/src/reader/laz.rs
+++ b/src/reader/laz.rs
@@ -1,5 +1,5 @@
 use super::ReadPoints;
-use crate::{raw, Error, Header, Point, Result};
+use crate::{raw, Header, Point, Result};
 use laz::LazDecompressor;
 use std::io::{Cursor, Read, Seek};
 

--- a/src/writer/laz.rs
+++ b/src/writer/laz.rs
@@ -66,11 +66,12 @@ mod tests {
 
     #[test]
     fn evlr() {
-        let mut vlr = Vlr::default();
-        vlr.user_id = "@gadomski".to_string();
-        vlr.record_id = 42;
-        vlr.description = "A great vlr".to_string();
-        vlr.data = b"some data".to_vec();
+        let vlr = Vlr {
+            user_id: "@gadomski".to_string(),
+            record_id: 42,
+            description: "A great vlr".to_string(),
+            data: b"some data".to_vec(),
+        };
         let mut builder = Builder::default();
         builder.version.minor = 4;
         builder.point_format.is_compressed = true;
@@ -79,8 +80,10 @@ mod tests {
         let cursor = Cursor::new(Vec::new());
         let mut writer = Writer::new(cursor, header).unwrap();
         for i in 0..5 {
-            let mut point = Point::default();
-            point.return_number = i;
+            let point = Point {
+                return_number: i,
+                ..Default::default()
+            };
             writer.write_point(point).unwrap();
         }
         let cursor = writer.into_inner().unwrap();

--- a/src/writer/laz.rs
+++ b/src/writer/laz.rs
@@ -12,7 +12,7 @@ pub(crate) struct PointWriter<'a, W: Write + Seek + Send> {
 impl<'a, W: Write + Seek + Send> PointWriter<'a, W> {
     pub(crate) fn new(write: W, header: Header) -> Result<PointWriter<'a, W>> {
         let buffer = Cursor::new(vec![0u8; header.point_format().len() as usize]);
-        let vlr = header.laz_vlr().ok_or(Error::LasZipVlrNotFound)?;
+        let vlr = header.laz_vlr()?;
         let compressor = LasZipCompressor::new(write, vlr)?;
 
         Ok(Self {


### PR DESCRIPTION
Hey,

while reading I did some minor cleaning:

fn is_laszip_vlr() was duplicate.
Helper function vlr_and_buffer was removed to simplify code. 
For that fn laz_vlr() needed to return an Error instead of an Option.
Test evlr needed some refactoring to make clippy happy.

Best Regards
Jonas