### PR TITLE
Add ReaderOption struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,13 +204,15 @@ pub use crate::{
     gps_time_type::GpsTimeType,
     header::{Builder, Header},
     point::Point,
-    reader::Reader,
+    reader::{Reader, ReaderOptions},
     transform::Transform,
     vector::Vector,
     version::Version,
     vlr::Vlr,
     writer::Writer,
 };
+#[cfg(feature = "laz")]
+pub use reader::LazParallelism;
 #[allow(deprecated)]
 pub use {reader::Read, writer::Write};
 

--- a/src/reader/laz.rs
+++ b/src/reader/laz.rs
@@ -12,7 +12,7 @@ pub(crate) struct PointReader<D: LazDecompressor> {
 
 #[cfg(feature = "laz-parallel")]
 impl<R: Read + Seek> PointReader<laz::ParLasZipDecompressor<R>> {
-    pub(crate) fn new(
+    pub(crate) fn new_parallel(
         read: R,
         header: Header,
     ) -> Result<PointReader<laz::ParLasZipDecompressor<R>>> {
@@ -27,7 +27,6 @@ impl<R: Read + Seek> PointReader<laz::ParLasZipDecompressor<R>> {
     }
 }
 
-#[cfg(not(feature = "laz-parallel"))]
 impl<R: Read + Seek + Send> PointReader<laz::LasZipDecompressor<'_, R>> {
     pub(crate) fn new(
         read: R,


### PR DESCRIPTION
This new structs allows users to select whether they want to use parallism when reading a LAZ file. By default, when the laz-parallel feature is enabled, parallelism will be used (as it was before)

A new Reader::with_options is added to create a Reader with non-default options.

Normally there is no API break

Fixes #116 