### PR TITLE
fix: don't preallocate from the untrusted header point count

### DIFF
--- a/src/copc.rs
+++ b/src/copc.rs
@@ -588,22 +588,38 @@ impl<R: Read + Seek> CopcEntryReader<'_, R> {
             .decompressor
             .get_mut()
             .seek(SeekFrom::Start(entry.offset))?;
-        points.reserve_exact(entry.point_count as usize);
+        // `entry.point_count` is an untrusted i64 read from the COPC hierarchy
+        // (`Entry::read_from`). A negative value cast to `usize` wraps to a
+        // number near `usize::MAX`, which then drives `reserve_exact` and the
+        // `resize` below. Reject negative and overflowing counts up front so a
+        // crafted COPC entry cannot force a huge allocation or a `capacity
+        // overflow` panic through this path.
+        let point_count =
+            u64::try_from(entry.point_count).map_err(|_| Error::PointRecordLengthOverflow {
+                n: entry.point_count as u64,
+                record_len: self.header.point_format().len(),
+            })?;
+        let point_count_usize = usize::try_from(point_count)?;
+        points.reserve_exact(point_count_usize);
 
-        let resize = usize::try_from(
-            entry.point_count as u64 * u64::from(self.header.point_format().len()),
-        )?;
+        let record_len = u64::from(self.header.point_format().len());
+        let resize = usize::try_from(point_count.checked_mul(record_len).ok_or_else(|| {
+            Error::PointRecordLengthOverflow {
+                n: point_count,
+                record_len: self.header.point_format().len(),
+            }
+        })?)?;
         self.buffer.get_mut().resize(resize, 0u8);
         self.decompressor.decompress_many(self.buffer.get_mut())?;
         self.buffer.set_position(0);
-        points.reserve(entry.point_count as usize);
+        points.reserve(point_count_usize);
 
-        for _ in 0..entry.point_count as usize {
+        for _ in 0..point_count_usize {
             let point = raw::Point::read_from(&mut self.buffer, self.header.point_format())
                 .map(|raw_point| Point::new(raw_point, self.header.transforms()))?;
             points.push(point);
         }
-        Ok(entry.point_count as u64)
+        Ok(point_count)
     }
 
     /// Returns a reference to the LAS header.

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,6 +157,21 @@ pub enum Error {
         version: Version,
     },
 
+    /// The header's point count and point data record length together imply a
+    /// point record body that overflows `u64` byte addressing, so the file
+    /// cannot describe a finite point stream. Reaching this means the
+    /// `number_of_point_records` / `point_data_record_length` pair is
+    /// inconsistent with any real file and was almost certainly crafted to
+    /// trigger a huge allocation or an arithmetic overflow in the reader.
+    #[error("point count {n} * point data record length {record_len} overflows u64")]
+    PointRecordLengthOverflow {
+        /// The number of point records from the header.
+        n: u64,
+
+        /// The point data record length from the header.
+        record_len: u16,
+    },
+
     /// Too many variable length records.
     #[error("too many variable length records: {0}")]
     TooManyVlrs(usize),

--- a/src/header/builder.rs
+++ b/src/header/builder.rs
@@ -106,6 +106,22 @@ impl Builder {
             Ordering::Equal => {} // pass
             Ordering::Greater => point_format.extra_bytes = raw_header.point_data_record_length - n,
         }
+        // Reject headers whose `number_of_point_records * point_data_record_length`
+        // overflows u64 before we hand the count to the read path, where it
+        // otherwise drives the preallocation in `Reader::read_all` and the
+        // `offset_to_end_of_points` seek computed in `Header::new`. Such a pair
+        // cannot describe a finite point stream, so this is an inconsistent
+        // header rather than a length to honour.
+        let record_len = raw_header.point_data_record_length;
+        if number_of_points
+            .checked_mul(u64::from(record_len))
+            .is_none()
+        {
+            return Err(Error::PointRecordLengthOverflow {
+                n: number_of_points,
+                record_len,
+            });
+        }
         Ok(Builder {
             date: NaiveDate::from_yo_opt(
                 i32::from(raw_header.file_creation_year),

--- a/src/point_data.rs
+++ b/src/point_data.rs
@@ -298,6 +298,13 @@ impl PointData {
     /// directly (e.g. against COPC chunks that bypass [Reader](crate::Reader)).
     /// Call `resize_for`, decompress into the returned slice, and then use the
     /// column accessors or [PointData::points] as usual.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n * record_len` overflows `usize`. Callers deriving `n` from
+    /// file data (a header point count, a COPC entry's `point_count`) must
+    /// validate it against the bytes actually available first — otherwise a
+    /// crafted file reaches this multiply.
     pub fn resize_for(&mut self, n: usize) -> &mut [u8] {
         let new_len = n.checked_mul(self.layout.record_len).expect("overflow");
         self.bytes.resize(new_len, 0u8);

--- a/src/raw/header.rs
+++ b/src/raw/header.rs
@@ -355,8 +355,10 @@ impl Header {
     /// assert_eq!(227, Header::default().offset_to_end_of_points());
     /// ```
     pub fn offset_to_end_of_points(&self) -> u64 {
-        u64::from(self.offset_to_point_data)
-            + self.number_of_point_records() * u64::from(self.point_data_record_length)
+        u64::from(self.offset_to_point_data).saturating_add(
+            self.number_of_point_records()
+                .saturating_mul(u64::from(self.point_data_record_length)),
+        )
     }
 
     /// Writes a raw header to a `Write`.

--- a/src/reader/las.rs
+++ b/src/reader/las.rs
@@ -25,7 +25,31 @@ impl<R: Read + Seek> ReadPoints for PointReader<R> {
         let points_left = self.header.number_of_points() - self.index;
         let n = points_left.min(n);
         let n_usize = usize::try_from(n)?;
-        out.resize(n_usize * record_len, 0u8);
+        // The header's `number_of_point_records` is untrusted and may name far
+        // more points than the stream carries. Honouring it verbatim lets a
+        // sub-kibibyte file force a multi-gibibyte allocation (or a `capacity
+        // overflow` panic once `n_usize * record_len` saturates `usize`) before
+        // a single point byte is read. Guard the multiply against `usize`
+        // overflow, and refuse to reserve more bytes than the stream actually
+        // holds — `read_exact` below still reports genuine short reads, so this
+        // only rejects allocations a valid file could never satisfy.
+        let alloc_bytes = n_usize.checked_mul(record_len).ok_or_else(|| {
+            crate::Error::PointRecordLengthOverflow {
+                n,
+                record_len: u16::try_from(record_len).unwrap_or(u16::MAX),
+            }
+        })?;
+        let cur = self.read.stream_position()?;
+        let stream_end = self.read.seek(SeekFrom::End(0))?;
+        let _ = self.read.seek(SeekFrom::Start(cur));
+        let remaining = stream_end.saturating_sub(cur);
+        if u64::try_from(alloc_bytes).unwrap_or(u64::MAX) > remaining {
+            return Err(crate::Error::PointRecordLengthOverflow {
+                n,
+                record_len: u16::try_from(record_len).unwrap_or(u16::MAX),
+            });
+        }
+        out.resize(alloc_bytes, 0u8);
         self.read.read_exact(out)?;
         self.index += n;
         Ok(n)

--- a/src/reader/laz.rs
+++ b/src/reader/laz.rs
@@ -46,7 +46,18 @@ where
         let points_left = self.header.number_of_points() - self.index;
         let n = points_left.min(n);
         let n_usize = usize::try_from(n)?;
-        out.resize(n_usize * record_len, 0u8);
+        // Guard the byte count against `usize` overflow before `resize`. A
+        // crafted header can make `number_of_point_records * record_len`
+        // saturate `usize`, which `Vec::resize` turns into a `capacity
+        // overflow` panic; `decompress_many` already reports truncated input,
+        // so we only reject what no valid stream could back.
+        let alloc_bytes = n_usize.checked_mul(record_len).ok_or_else(|| {
+            crate::Error::PointRecordLengthOverflow {
+                n,
+                record_len: u16::try_from(record_len).unwrap_or(u16::MAX),
+            }
+        })?;
+        out.resize(alloc_bytes, 0u8);
         self.decompressor.decompress_many(out)?;
         self.index += n;
         Ok(n)

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -27,3 +27,127 @@ fn issue_136() {
     let reader = Reader::from_path(file_name).unwrap();
     assert_eq!(reader.header().number_of_points(), 106);
 }
+
+// Regression tests for the untrusted `number_of_point_records` / LargeFile
+// count preallocation class (c.f. issue #125 "OOM crashes in COPC LAZ files").
+//
+// The header's point count is attacker-controlled and was previously honoured
+// verbatim by `Reader::read_all`, which reserved `count * record_len` bytes
+// before reading a single point. A sub-kibibyte file with a crafted count
+// could therefore force a multi-gibibyte allocation, a `capacity overflow`
+// panic, or — on LAS 1.4 — an `attempt to multiply with overflow` panic
+// during `Reader::new`. These tests assert the reader now returns a
+// structured `las::Error` instead of panicking or attempting the allocation.
+mod untrusted_point_count {
+    use byteorder::{LittleEndian as LE, WriteBytesExt};
+    use las::Reader;
+    use std::io::Cursor;
+
+    fn write_common(
+        buf: &mut Vec<u8>,
+        version_major: u8,
+        version_minor: u8,
+        header_size: u16,
+        offset_to_point_data: u32,
+        point_data_record_format: u8,
+        point_data_record_length: u16,
+        number_of_point_records: u32,
+    ) {
+        buf.extend_from_slice(b"LASF");
+        buf.write_u16::<LE>(0).unwrap(); // file_source_id
+        buf.write_u16::<LE>(0).unwrap(); // global_encoding
+        buf.extend_from_slice(&[0u8; 16]); // guid
+        buf.write_u8(version_major).unwrap();
+        buf.write_u8(version_minor).unwrap();
+        buf.extend_from_slice(&[0u8; 32]); // system_identifier
+        buf.extend_from_slice(&[0u8; 32]); // generating_software
+        buf.write_u16::<LE>(0).unwrap(); // file_creation_day_of_year
+        buf.write_u16::<LE>(2026).unwrap(); // file_creation_year
+        buf.write_u16::<LE>(header_size).unwrap();
+        buf.write_u32::<LE>(offset_to_point_data).unwrap();
+        buf.write_u32::<LE>(0).unwrap(); // number_of_variable_length_records
+        buf.write_u8(point_data_record_format).unwrap();
+        buf.write_u16::<LE>(point_data_record_length).unwrap();
+        buf.write_u32::<LE>(number_of_point_records).unwrap();
+        for _ in 0..5 {
+            buf.write_u32::<LE>(0).unwrap(); // number_of_points_by_return
+        }
+        for _ in 0..12 {
+            buf.write_f64::<LE>(0.0).unwrap(); // scales + offsets + min/max
+        }
+    }
+
+    fn las12_header(count: u32, record_len: u16) -> Vec<u8> {
+        let mut buf = Vec::new();
+        write_common(&mut buf, 1, 2, 227, 227, 0, record_len, count);
+        assert_eq!(buf.len(), 227);
+        buf
+    }
+
+    // LAS 1.4 LargeFile: legacy u32 count = 0 forces fallback to the u64
+    // LargeFile field. 227 (common) + 8 (waveform) + 12 (evlr) + 128 = 375.
+    fn las14_large_file_header(count: u64, record_len: u16) -> Vec<u8> {
+        let mut buf = Vec::new();
+        write_common(&mut buf, 1, 4, 375, 375, 0, record_len, 0);
+        buf.write_u64::<LE>(0).unwrap(); // start_of_waveform_data_packet_record
+        buf.write_u64::<LE>(0).unwrap(); // start_of_first_evlr
+        buf.write_u32::<LE>(0).unwrap(); // number_of_evlrs
+        buf.write_u64::<LE>(count).unwrap();
+        for _ in 0..15 {
+            buf.write_u64::<LE>(0).unwrap(); // number_of_points_by_return
+        }
+        assert_eq!(buf.len(), 375);
+        buf
+    }
+
+    /// A LAS 1.2 file whose header claims ~1.07e9 points but whose body is
+    /// only 64 bytes. Previously this made `read_all` try to reserve ~20 GiB
+    /// before reading; now it must return a structured error.
+    #[test]
+    fn las12_huge_count_short_body_errors_instead_of_allocating() {
+        let mut data = las12_header(0x4000_0000, 20);
+        data.extend_from_slice(&[0u8; 64]);
+        let mut reader = Reader::new(Cursor::new(data)).unwrap();
+        let err = reader.read_all().unwrap_err();
+        assert!(
+            matches!(err, las::Error::PointRecordLengthOverflow { .. }),
+            "expected PointRecordLengthOverflow, got {err:?}"
+        );
+    }
+
+    /// A LAS 1.4 file whose LargeFile count is `u64::MAX`: the
+    // `count * record_len` product overflows `u64`. Previously this panicked
+    // with `attempt to multiply with overflow` (debug) during `Reader::new`,
+    // or `capacity overflow` (release) inside `read_all`; now `Reader::new`
+    // must return the structured error.
+    #[test]
+    fn las14_large_file_overflow_count_errors_in_reader_new() {
+        let mut data = las14_large_file_header(u64::MAX, 20);
+        data.extend_from_slice(&[0u8; 64]);
+        let err = match Reader::new(Cursor::new(data)) {
+            Ok(_) => panic!("expected Reader::new to reject overflowing large-file count"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, las::Error::PointRecordLengthOverflow { .. }),
+            "expected PointRecordLengthOverflow, got {err:?}"
+        );
+    }
+
+    /// Positive control: a well-formed LAS 1.2 file whose header count matches
+    /// its body must still read end-to-end (guards against over-eager rejection).
+    #[test]
+    fn valid_short_las12_round_trips() {
+        let n: u32 = 3;
+        let mut data = las12_header(n, 20);
+        for i in 0..n {
+            let mut rec = vec![0u8; 20];
+            rec[0..4].copy_from_slice(&(i as i32).to_le_bytes()); // x
+            data.extend_from_slice(&rec);
+        }
+        let mut reader = Reader::new(Cursor::new(data)).unwrap();
+        assert_eq!(reader.header().number_of_points(), u64::from(n));
+        let pd = reader.read_all().unwrap();
+        assert_eq!(pd.len(), usize::try_from(n).unwrap());
+    }
+}


### PR DESCRIPTION
CONTRIBUTING says to send a PR with a failing test to demonstrate a bug, so here's one — on the OOM axis of #125, but reachable from plain `Reader::read_all` on uncompressed LAS, not just COPC.

`number_of_point_records` (u32 in 1.0–1.3, u64 via the 1.4 LargeFile extension) is attacker-controlled, and the read path reserved `count * record_len` bytes before reading a single point byte, never reconciling the count against the remaining stream. Three repros, all from a ~300-byte file:

| header | result on `main` |
| --- | --- |
| LAS 1.2, count `0x4000_0000`, 64-byte body | `read_all` reserves 20 GiB up front |
| LAS 1.4 LargeFile count `u64::MAX` | `capacity overflow` panic in `out.resize(usize::MAX * 20, 0)` |
| same, debug build | `attempt to multiply with overflow` in `offset_to_end_of_points`, inside `Reader::new` before any I/O |

Rather than patch the one sink, this covers the class — every place an untrusted count reaches an allocation or a multiply:

- `Builder::new` rejects a `count * point_data_record_length` product that overflows u64 (new `Error::PointRecordLengthOverflow`), so `Reader::new` errors instead of panicking.
- `raw::Header::offset_to_end_of_points` uses saturating arithmetic.
- both `fill_into_bytes` backends guard the multiply with `checked_mul`; the LAS backend also refuses to reserve more bytes than the stream holds. `read_exact`/`decompress_many` still report genuine short reads, so only unsatisfiable reservations get rejected.
- `CopcEntryReader::read_entry_points` validates the hierarchy's signed `point_count` before casting to `usize` — a negative count wrapped to ~`usize::MAX` and drove `reserve_exact`.
- documented the `PointData::resize_for` overflow panic, which the same untrusted counts reach through the direct-decompressor entry point. Left as a panic since making it fallible is a signature change — happy to do that instead if you'd prefer.

Tests: three cases in `tests/regressions.rs` (both malicious headers + a positive control that a well-formed short file still reads). `cargo test` green with default, `--all-features`, and `--no-default-features`; `cargo clippy --all-features` and nightly `cargo fmt --check` clean.