### PR TITLE
Do not swallow hierarchy error reason and more informative error msg

### DIFF
--- a/src/copc.rs
+++ b/src/copc.rs
@@ -349,17 +349,28 @@ impl CopcHierarchyVlr {
     /// Reads the CopcHierarchyVlr from the Vlr payload with specifications from copc_info.
     pub fn read_from_with(vlr: &Vlr, copc_info: &CopcInfoVlr) -> Result<CopcHierarchyVlr> {
         let read_page = |offset: u64, byte_size: u64| {
-            let start = offset
+            let start: usize = offset
                 .checked_sub(copc_info.root_hier_offset)
-                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid COPC page"))?;
-            let start = usize::try_from(start)?;
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid COPC page: Root page should be the first Page in the Copc Hierarchy EVLR",
+                    )
+                })?.try_into()?;
             let end = start
                 .checked_add(usize::try_from(byte_size)?)
-                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid COPC page"))?;
-            let data = vlr
-                .data
-                .get(start..end)
-                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid COPC page"))?;
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid COPC page: Page end address overflows usize",
+                    )
+                })?;
+            let data = vlr.data.get(start..end).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid COPC page: Page is longer than the Copc Hierarchy EVLR",
+                )
+            })?;
             Page::read_from(data)
         };
         let root = read_page(copc_info.root_hier_offset, copc_info.root_hier_size)?;
@@ -508,19 +519,19 @@ impl Header {
     /// Retrieves the COPC hierarchy EVLR (Extended Variable Length Record) if available.
     ///
     /// This function searches through the available EVLRs to find the COPC hierarchy EVLR,
-    /// and then attempts  to parse it using the COPC info VLR.
+    /// and then attempts to parse it using the COPC info VLR.
     ///
     /// # Returns
     ///
-    /// * `Some(CopcHierarchyVlr)` - If the COPC hierarchy EVLR exists and can be successfully parsed
-    /// * `None` - If the COPC info VLR doesn't exist, the COPC hierarchy EVLR doesn't exist,
-    ///   or if there was an error parsing the COPC hierarchy EVLRto parse it using the CopcInfoVlr.
-    pub fn copc_hierarchy_evlr(&self) -> Option<CopcHierarchyVlr> {
+    /// * `Some(Ok(CopcHierarchyVlr))` - If the COPC hierarchy EVLR exists and is successfully parsed
+    /// * `Some(Err(Error))` - If the COPC hierarchy EVLR exists, but parsing fails
+    /// * `None` - If the COPC info VLR doesn't exist or the COPC hierarchy EVLR doesn't exist,
+    pub fn copc_hierarchy_evlr(&self) -> Option<Result<CopcHierarchyVlr>> {
         let copc_info = self.copc_info_vlr()?;
         self.evlrs()
             .iter()
             .find(|vlr| vlr.is_copc_hierarchy())
-            .and_then(|vlr| CopcHierarchyVlr::read_from_with(vlr, &copc_info).ok())
+            .map(|vlr| CopcHierarchyVlr::read_from_with(vlr, &copc_info))
     }
 }
 
@@ -584,7 +595,7 @@ impl<R: Read + Seek> CopcReader<'_, R> {
         let copc_info = header.copc_info_vlr().ok_or(Error::CopcInfoVlrNotFound)?;
         let hierarchy = header
             .copc_hierarchy_evlr()
-            .ok_or(Error::CopcHierarchyEvlrNotFound)?;
+            .ok_or(Error::CopcHierarchyEvlrNotFound)??;
         let hierarchy = hierarchy.iter_entries().collect::<Result<Vec<_>>>()?;
         let hierarchy = hierarchy
             .into_iter()
@@ -830,7 +841,7 @@ mod tests {
     fn test_vlr_copc_autzen() {
         let reader = Reader::from_path("tests/data/autzen.copc.laz").expect("Cannot open reader");
         let copcinfo = reader.header().copc_info_vlr().unwrap();
-        let copchier = reader.header().copc_hierarchy_evlr().unwrap();
+        let copchier = reader.header().copc_hierarchy_evlr().unwrap().unwrap();
         assert!(copcinfo.root_hier_offset == 4336);
         assert!(copcinfo.root_hier_size == 32);
         assert!(copchier.root.entries[0].key == VoxelKey::ROOT);

--- a/src/copc.rs
+++ b/src/copc.rs
@@ -1,6 +1,6 @@
 //! [COPC](https://copc.io/) header data
 
-use crate::{Bounds, PointData, PointDataBuilder, Vector};
+use crate::{Bounds, Error, Header, PointData, PointDataBuilder, Result, Vector, Vlr};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use laz::record::{LayeredPointRecordDecompressor, RecordDecompressor};
 use std::{
@@ -11,23 +11,13 @@ use std::{
     path::Path,
 };
 
-/// The user id of the Copc VLRs.
-pub const USER_ID: &str = "copc";
-
-/// The description of the Copc VLRs.
-pub const DESCRIPTION: &str = "https://copc.io";
-
-use crate::{Error, Header, Result, Vlr};
-
 /// The COPC Info Vlr.
 ///
 /// Requirements:
 ///
 /// - The info VLR MUST exist.
-/// - The info VLR MUST be the first VLR in the file (must begin at offset 375
-///   from the beginning of the file).
-/// - The info VLR is 160 bytes described by the following structure. reserved
-///   elements MUST be set to 0.
+/// - The info VLR MUST be the first VLR in the file (must begin at offset 375 from the beginning of the file).
+/// - The info VLR is 160 bytes described by the following structure. reserved elements MUST be set to 0.
 #[derive(Clone, Debug)]
 pub struct CopcInfoVlr {
     /// Actual (unscaled) X coordinate of center of octree
@@ -56,6 +46,8 @@ pub struct CopcInfoVlr {
 impl CopcInfoVlr {
     /// The record id of the CopcInfo VLR header.
     pub const RECORD_ID: u16 = 1;
+    /// The user id of the CopcInfo VLR header.
+    pub const USER_ID: &str = "copc";
 
     /// Reads the Vlr data from the source.
     ///
@@ -83,8 +75,7 @@ impl CopcInfoVlr {
 
     /// Writes the Vlr data to the source.
     ///
-    /// This only writes the payload data the vlr header should be written
-    /// before-hand.
+    /// This only writes the payload data
     pub fn write_to<W: Write>(&self, dst: &mut W) -> Result<()> {
         dst.write_f64::<LittleEndian>(self.center_x)?;
         dst.write_f64::<LittleEndian>(self.center_y)?;
@@ -106,7 +97,11 @@ impl TryFrom<&Vlr> for CopcInfoVlr {
     type Error = Error;
 
     fn try_from(value: &Vlr) -> Result<Self> {
-        Self::read_from::<&[u8]>(value.data.as_ref())
+        if value.record_id == Self::RECORD_ID && value.user_id == Self::USER_ID {
+            Self::read_from::<&[u8]>(value.data.as_ref())
+        } else {
+            Err(Error::CopcInfoVlrNotFound)
+        }
     }
 }
 
@@ -167,6 +162,7 @@ impl VoxelKey {
             z: self.z >> 1,
         }
     }
+
     /// Calculates bounds of the VoxelKey.
     /// Serves as a guidance implementation.
     pub fn bounds(&self, copc_info: &CopcInfoVlr) -> Bounds {
@@ -212,7 +208,7 @@ impl VoxelKey {
     };
 
     /// Read a VoxelKey from Vlr Payload data.
-    pub fn read_from<R: Read>(read: &mut R) -> Result<Self> {
+    fn read_from<R: Read>(read: &mut R) -> Result<Self> {
         Ok(Self {
             l: read.read_i32::<LittleEndian>()?,
             x: read.read_i32::<LittleEndian>()?,
@@ -312,19 +308,16 @@ impl Page {
 
 /// The hierarchy VLR MUST exist.
 ///
-/// Like EPT, COPC stores hierarchy information to allow a reader to locate
-/// points that are in a particular octree node. Also like EPT, the hierarchy
-/// MAY be arranged in a tree of pages, but SHALL always consist of at least ONE
-/// hierarchy page.  The VLR data consists of one or more hierarchy pages. Each
-/// hierarchy data page is written as follows:
+/// Like EPT, COPC stores hierarchy information to allow a reader to locate points that are in a particular octree node.
+/// Also like EPT, the hierarchy MAY be arranged in a tree of pages, but SHALL always consist of at least ONE hierarchy page.
+/// The VLR data consists of one or more hierarchy pages. Each hierarchy data page is written as follows:
 ///
-/// VoxelKey corresponds to the naming of EPT data files.  octree hierarchy is
-/// arranged in pages. The COPC VLR provides information describing the location
-/// and size of root hierarchy page. The root hierarchy page can be used to
-/// traverse to child pages. Each entry in a hierarchy page either refers to a
-/// child hierarchy page, octree node data chunk, or an empty octree node. The
-/// size and file offset of each data chunk is provided in the hierarchy
-/// entries, allowing the chunks to be directly read for decoding.
+/// VoxelKey corresponds to the naming of EPT data files.
+/// The octree hierarchy is arranged in pages.
+/// The COPC VLR provides information describing the location and size of root hierarchy page.
+/// The root hierarchy page can be used to traverse to child pages.
+/// Each entry in a hierarchy page either refers to a child hierarchy page, octree node data chunk, or an empty octree node.
+/// The size and file offset of each data chunk is provided in the hierarchy entries, allowing the chunks to be directly read for decoding.
 #[derive(Clone, Debug)]
 pub struct CopcHierarchyVlr {
     root: Page,
@@ -334,6 +327,8 @@ pub struct CopcHierarchyVlr {
 impl CopcHierarchyVlr {
     /// The record id of the CopcHierarchy VLR header.
     pub const RECORD_ID: u16 = 1000;
+    /// The user id of the CopcHierarchy VLR header.
+    pub const USER_ID: &str = "copc";
 
     /// Writes the Vlr data to the source.
     ///
@@ -348,6 +343,10 @@ impl CopcHierarchyVlr {
 
     /// Reads the CopcHierarchyVlr from the Vlr payload with specifications from copc_info.
     pub fn read_from_with(vlr: &Vlr, copc_info: &CopcInfoVlr) -> Result<CopcHierarchyVlr> {
+        if vlr.record_id != Self::RECORD_ID || vlr.user_id != Self::USER_ID {
+            return Err(Error::CopcHierarchyEvlrNotFound);
+        }
+
         let read_page = |offset: u64, byte_size: u64| {
             let start: usize = offset
                 .checked_sub(copc_info.root_hier_offset)
@@ -475,7 +474,7 @@ impl Vlr {
     /// assert!(&vlr.is_copc_info());
     /// ```
     pub fn is_copc_info(&self) -> bool {
-        self.user_id == USER_ID && self.record_id == CopcInfoVlr::RECORD_ID
+        self.user_id == CopcInfoVlr::USER_ID && self.record_id == CopcInfoVlr::RECORD_ID
     }
 }
 
@@ -513,7 +512,7 @@ impl Vlr {
     /// assert!(vlr.is_copc_hierarchy());
     /// ```
     pub fn is_copc_hierarchy(&self) -> bool {
-        self.user_id == USER_ID && self.record_id == CopcHierarchyVlr::RECORD_ID
+        self.user_id == CopcHierarchyVlr::USER_ID && self.record_id == CopcHierarchyVlr::RECORD_ID
     }
 }
 
@@ -888,6 +887,8 @@ mod tests {
             .unwrap();
         let vlr = Vlr {
             data,
+            user_id: CopcHierarchyVlr::USER_ID.to_owned(),
+            record_id: CopcHierarchyVlr::RECORD_ID,
             ..Default::default()
         };
         let info = CopcInfoVlr {

--- a/src/copc.rs
+++ b/src/copc.rs
@@ -486,13 +486,15 @@ impl Header {
     ///
     /// # Returns
     ///
-    /// * `Some(CopcInfolr)` - If the COPC Info VLR exists and can be successfully parsed
-    /// * `None` - If the COPC Info VLR doesn't exist or if there was an error parsing it.
-    pub fn copc_info_vlr(&self) -> Option<CopcInfoVlr> {
+    /// * `Ok(Some(CopcInfoVlr))` - If the COPC Info VLR exists and can be successfully parsed
+    /// * `Ok(None)` - If the COPC Info VLR doesn't exist.
+    /// * `Err(crate::Error)` - If the COPC Info VLR exists, but parsing failed
+    pub fn copc_info_vlr(&self) -> Result<Option<CopcInfoVlr>> {
         self.vlrs
             .iter()
             .find(|vlr| vlr.is_copc_info())
-            .and_then(|vlr| vlr.try_into().ok())
+            .map(|vlr| vlr.try_into())
+            .transpose()
     }
 }
 
@@ -523,15 +525,18 @@ impl Header {
     ///
     /// # Returns
     ///
-    /// * `Some(Ok(CopcHierarchyVlr))` - If the COPC hierarchy EVLR exists and is successfully parsed
-    /// * `Some(Err(Error))` - If the COPC hierarchy EVLR exists, but parsing fails
-    /// * `None` - If the COPC info VLR doesn't exist or the COPC hierarchy EVLR doesn't exist,
-    pub fn copc_hierarchy_evlr(&self) -> Option<Result<CopcHierarchyVlr>> {
-        let copc_info = self.copc_info_vlr()?;
+    /// * `Ok(Some(CopcHierarchyVlr))` - If the COPC hierarchy EVLR exists and is successfully parsed
+    /// * `Ok(None)` - If the COPC info VLR doesn't exist or the COPC hierarchy EVLR doesn't exist,
+    /// * `Err(Error)` - If the COPC hierarchy EVLR exists, but parsing fails
+    pub fn copc_hierarchy_evlr(&self) -> Result<Option<CopcHierarchyVlr>> {
+        let Some(copc_info) = self.copc_info_vlr()? else {
+            return Ok(None);
+        };
         self.evlrs()
             .iter()
             .find(|vlr| vlr.is_copc_hierarchy())
             .map(|vlr| CopcHierarchyVlr::read_from_with(vlr, &copc_info))
+            .transpose()
     }
 }
 
@@ -592,10 +597,10 @@ impl<R: Read + Seek> CopcReader<'_, R> {
     /// ```
     pub fn new(mut read: R) -> Result<Self> {
         let header = Header::new(read.by_ref())?;
-        let copc_info = header.copc_info_vlr().ok_or(Error::CopcInfoVlrNotFound)?;
+        let copc_info = header.copc_info_vlr()?.ok_or(Error::CopcInfoVlrNotFound)?;
         let hierarchy = header
-            .copc_hierarchy_evlr()
-            .ok_or(Error::CopcHierarchyEvlrNotFound)??;
+            .copc_hierarchy_evlr()?
+            .ok_or(Error::CopcHierarchyEvlrNotFound)?;
         let hierarchy = hierarchy.iter_entries().collect::<Result<Vec<_>>>()?;
         let hierarchy = hierarchy
             .into_iter()
@@ -840,7 +845,7 @@ mod tests {
     #[test]
     fn test_vlr_copc_autzen() {
         let reader = Reader::from_path("tests/data/autzen.copc.laz").expect("Cannot open reader");
-        let copcinfo = reader.header().copc_info_vlr().unwrap();
+        let copcinfo = reader.header().copc_info_vlr().unwrap().unwrap();
         let copchier = reader.header().copc_hierarchy_evlr().unwrap().unwrap();
         assert!(copcinfo.root_hier_offset == 4336);
         assert!(copcinfo.root_hier_size == 32);

--- a/src/crs.rs
+++ b/src/crs.rs
@@ -11,9 +11,16 @@ use crate::{Error, Header, Result, Vlr};
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::{Cursor, Seek, SeekFrom};
 
-const MAIN_VLR_ID: u16 = 34735;
-const DOUBLE_VLR_ID: u16 = 34736;
-const ASCII_VLR_ID: u16 = 34737;
+/// User Id of CRS VLRs
+pub const CRS_USER_ID: &str = "LASF_Projection";
+/// Record Id of WKT CRS VLR
+pub const WKT_RECORD_ID: u16 = 2112;
+/// Record Id of main GeoTIFF CRS VLR
+pub const MAIN_VLR_ID: u16 = 34735;
+/// Record Id of Double GeoTIFF CRS VLR
+pub const DOUBLE_VLR_ID: u16 = 34736;
+/// Record Id of ASCII GeoTIFF CRS VLR
+pub const ASCII_VLR_ID: u16 = 34737;
 
 impl Header {
     /// Removes all CRS (E)VLRs from the header
@@ -36,8 +43,6 @@ impl Header {
     /// Adds a WKT CRS VLR to the header
     ///
     /// Returns Err if the header already contains CRS (E)VLRs or the Las version is below 1.4.
-    ///
-    /// The WKT bytes can be obtained from a horizontal EPSG code by using the [crs-definitions](https://docs.rs/crs-definitions/latest/crs_definitions/) crate
     ///
     /// # Examples
     ///
@@ -64,8 +69,8 @@ impl Header {
 
         let num_bytes = wkt_crs_bytes.len();
         let vlr = Vlr {
-            user_id: "LASF_Projection".to_string(),
-            record_id: 2112,
+            user_id: CRS_USER_ID.to_string(),
+            record_id: WKT_RECORD_ID,
             description: String::new(),
             data: wkt_crs_bytes,
         };
@@ -138,6 +143,65 @@ impl Header {
         } else {
             Ok(None)
         }
+    }
+}
+
+impl Vlr {
+    /// Check if the vlr is a projection (coordinate reference system) VLR
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use las::Vlr;
+    /// let mut vlr = Vlr::default();
+    /// vlr.user_id = "LASF_Projection".to_string();
+    /// vlr.record_id = 2112;
+    /// assert!(vlr.is_crs());
+    /// ```
+    pub fn is_crs(&self) -> bool {
+        matches!(
+            (self.user_id.as_str(), self.record_id),
+            (
+                CRS_USER_ID,
+                WKT_RECORD_ID | MAIN_VLR_ID | ASCII_VLR_ID | DOUBLE_VLR_ID
+            )
+        )
+    }
+
+    /// Returns true if it's a well-known WKT coordinate reference system VLR.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use las::Vlr;
+    /// let mut vlr = Vlr::default();
+    /// vlr.user_id = "LASF_Projection".to_string();
+    /// vlr.record_id = 2112;
+    /// assert!(vlr.is_wkt_crs());
+    /// ```
+    pub fn is_wkt_crs(&self) -> bool {
+        matches!(
+            (self.user_id.as_str(), self.record_id),
+            (CRS_USER_ID, WKT_RECORD_ID)
+        )
+    }
+
+    /// Returns true if it's a geotiff coordinate reference system VLR.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use las::Vlr;
+    /// let mut vlr = Vlr::default();
+    /// vlr.user_id = "LASF_Projection".to_string();
+    /// vlr.record_id = 34735;
+    /// assert!(vlr.is_geotiff_crs());
+    /// ```
+    pub fn is_geotiff_crs(&self) -> bool {
+        matches!(
+            (self.user_id.as_str(), self.record_id),
+            (CRS_USER_ID, MAIN_VLR_ID | ASCII_VLR_ID | DOUBLE_VLR_ID)
+        )
     }
 }
 

--- a/src/laz.rs
+++ b/src/laz.rs
@@ -4,24 +4,26 @@ use crate::{Error, Header, Result, Vlr};
 use laz::{LazItemRecordBuilder, LazItemType, LazVlr};
 use std::io::Cursor;
 
-/// Returns true if this [Vlr] is the laszip Vlr.
-///
-/// # Examples
-///
-/// ```
-/// #[cfg(feature = "laz")]
-/// {
-/// use las::{laz, Vlr};
-///
-/// let mut vlr = Vlr::default();
-/// assert!(!laz::is_laszip_vlr(&vlr));
-/// vlr.user_id = "laszip encoded".to_string();
-/// vlr.record_id = 22204;
-/// assert!(laz::is_laszip_vlr(&vlr));
-/// }
-/// ```
-pub fn is_laszip_vlr(vlr: &Vlr) -> bool {
-    vlr.user_id == LazVlr::USER_ID && vlr.record_id == LazVlr::RECORD_ID
+impl Vlr {
+    /// Returns true if this [Vlr] is the laszip Vlr.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[cfg(feature = "laz")]
+    /// {
+    /// use las::{laz, Vlr};
+    ///
+    /// let mut vlr = Vlr::default();
+    /// assert!(!vlr.is_laszip());
+    /// vlr.user_id = "laszip encoded".to_string();
+    /// vlr.record_id = 22204;
+    /// assert!(vlr.is_laszip());
+    /// }
+    /// ```
+    pub fn is_laszip(&self) -> bool {
+        self.user_id == LazVlr::USER_ID && self.record_id == LazVlr::RECORD_ID
+    }
 }
 
 impl Header {
@@ -111,7 +113,7 @@ impl Header {
     pub fn laz_vlr(&self) -> Result<LazVlr> {
         self.vlrs
             .iter()
-            .find(|vlr| is_laszip_vlr(vlr))
+            .find(|vlr| vlr.is_laszip())
             .map_or(Err(Error::LasZipVlrNotFound), |vlr| vlr.try_into())
     }
 }

--- a/src/vlr.rs
+++ b/src/vlr.rs
@@ -151,60 +151,6 @@ impl Vlr {
         self.data.len() > u16::MAX as usize
     }
 
-    /// Check if the vlr is a projection (coordinate reference system) VLR
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use las::Vlr;
-    /// let mut vlr = Vlr::default();
-    /// vlr.user_id = "LASF_Projection".to_string();
-    /// vlr.record_id = 2112;
-    /// assert!(vlr.is_crs());
-    /// ```
-    pub fn is_crs(&self) -> bool {
-        matches!(
-            (self.user_id.to_lowercase().as_str(), self.record_id),
-            ("lasf_projection", 2112 | 34735..=34737)
-        )
-    }
-
-    /// Returns true if it's a well-known WKT coordinate reference system VLR.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use las::Vlr;
-    /// let mut vlr = Vlr::default();
-    /// vlr.user_id = "LASF_Projection".to_string();
-    /// vlr.record_id = 2112;
-    /// assert!(vlr.is_wkt_crs());
-    /// ```
-    pub fn is_wkt_crs(&self) -> bool {
-        matches!(
-            (self.user_id.to_lowercase().as_str(), self.record_id),
-            ("lasf_projection", 2112)
-        )
-    }
-
-    /// Returns true if it's a geotiff coordinate reference system VLR.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use las::Vlr;
-    /// let mut vlr = Vlr::default();
-    /// vlr.user_id = "LASF_Projection".to_string();
-    /// vlr.record_id = 34735;
-    /// assert!(vlr.is_geotiff_crs());
-    /// ```
-    pub fn is_geotiff_crs(&self) -> bool {
-        matches!(
-            (self.user_id.to_lowercase().as_str(), self.record_id),
-            ("lasf_projection", 34735..=34737)
-        )
-    }
-
     fn record_length_after_header(&self, is_extended: bool) -> Result<raw::vlr::RecordLength> {
         if is_extended {
             Ok(raw::vlr::RecordLength::Evlr(self.data.len() as u64))

--- a/tests/laszip.rs
+++ b/tests/laszip.rs
@@ -189,7 +189,7 @@ mod laz_compression_test {
         // Check that the header was properly updated when writing
         // We need to remove the laszip VLR and unset is_compressed to compare
         let mut builder = las::Builder::from(writer.header().clone());
-        builder.vlrs.retain(|vlr| !las::laz::is_laszip_vlr(vlr));
+        builder.vlrs.retain(|vlr| !vlr.is_laszip());
         builder.point_format.is_compressed = false;
         let writer_header_normalized = builder.into_header().unwrap();
         assert_eq!(&writer_header_normalized, reader.header());


### PR DESCRIPTION
I came across a COPC file with a bad hierarchy (among other things).
The root hierachy page was not the first page in the hierarchy evlr, meaning that we get an error in the checked_sub in `CopcHierarchyVlr::read_from_with` where we read the hierarchy from an in-memory VLR.

The spec says this:
```
  // File offset to the first hierarchy page
  uint64_t root_hier_offset;
```
So I am fairly certain that the root page should be first and our implementation is OK, though not as robust as other readers that seek directly to the Page data in the file instead of seeking to the Page data in an already loaded VLR.

The current implementation of the CopcReader maps any hierarchy parsing error to CopcHierarchyEvlrNotFound.
We should instead return a more informative errors.